### PR TITLE
Avoid a DeprecationWarning

### DIFF
--- a/asciidoc.conf
+++ b/asciidoc.conf
@@ -29,7 +29,7 @@ empty=
 sp=" "
 # Attribute and AttributeList element patterns.
 attributeentry-pattern=^:(?P<attrname>\w[^.]*?)(\.(?P<attrname2>.*?))?:(\s+(?P<attrvalue>.*))?$
-attributelist-pattern=(?u)(^\[\[(?P<id>[\w_:][\w_:.-]*)(,(?P<reftext>.*?))?\]\]$)|(^\[(?P<attrlist>.*)\]$)
+attributelist-pattern=(^\[\[(?P<id>[\w_:][\w_:.-]*)(,(?P<reftext>.*?))?\]\]$)|(^\[(?P<attrlist>.*)\]$)
 # Substitution attributes for escaping AsciiDoc processing.
 amp=&
 lt=<
@@ -288,10 +288,10 @@ endif::no-inline-literal[]
 # Block macros
 #-------------
 # Macros using default syntax.
-(?u)^(?P<name>image|unfloat|toc)::(?P<target>\S*?)(\[(?P<attrlist>.*?)\])$=#
+^(?P<name>image|unfloat|toc)::(?P<target>\S*?)(\[(?P<attrlist>.*?)\])$=#
 
 # Passthrough macros.
-(?u)^(?P<name>pass)::(?P<subslist>\S*?)(\[(?P<passtext>.*?)\])$=#
+^(?P<name>pass)::(?P<subslist>\S*?)(\[(?P<passtext>.*?)\])$=#
 
 ^'{3,}$=#ruler
 ^<{3,}$=#pagebreak

--- a/asciidoc.py
+++ b/asciidoc.py
@@ -463,7 +463,7 @@ def parse_options(options,allowed,errmsg):
 
 def symbolize(s):
     """Drop non-symbol characters and convert to lowercase."""
-    return re.sub(r'(?u)[^\w\-_]', '', s).lower()
+    return re.sub(r'[^\w\-_]', '', s).lower()
 
 def is_name(s):
     """Return True if s is valid attribute, macro or tag name
@@ -1746,7 +1746,7 @@ class AttributeEntry:
                 attr.name = attr.name[:-1]
                 attr.value = None
             # Strip white space and illegal name chars.
-            attr.name = re.sub(r'(?u)[^\w\-_]', '', attr.name).lower()
+            attr.name = re.sub(r'[^\w\-_]', '', attr.name).lower()
             # Don't override most command-line attributes.
             if attr.name in config.cmd_attrs \
                     and attr.name not in ('trace','numbered'):
@@ -1946,7 +1946,7 @@ class Title:
             if ul != s[:ul_len]: return False
             # Don't be fooled by back-to-back delimited blocks, require at
             # least one alphanumeric character in title.
-            if not re.search(r'(?u)\w',title): return False
+            if not re.search(r'\w',title): return False
             mo = re.match(Title.pattern, title)
             if mo:
                 Title.attributes = mo.groupdict()
@@ -2104,7 +2104,7 @@ class Section:
         """
         # Replace non-alpha numeric characters in title with underscores and
         # convert to lower case.
-        base_id = re.sub(r'(?u)\W+', '_', title).strip('_').lower()
+        base_id = re.sub(r'\W+', '_', title).strip('_').lower()
         if 'ascii-ids' in document.attributes:
             # Replace non-ASCII characters with ASCII equivalents.
             import unicodedata
@@ -3602,7 +3602,7 @@ class Tables(AbstractBlocks):
 
 class Macros:
     # Default system macro syntax.
-    SYS_RE = r'(?u)^(?P<name>[\\]?\w(\w|-)*?)::(?P<target>\S*?)' + \
+    SYS_RE = r'^(?P<name>[\\]?\w(\w|-)*?)::(?P<target>\S*?)' + \
              r'(\[(?P<attrlist>.*?)\])$'
     def __init__(self):
         self.macros = []        # List of Macros.
@@ -4478,7 +4478,7 @@ class Config:
         rdr.open(fname)
         message.linenos = None
         self.fname = fname
-        reo = re.compile(r'(?u)^\[(?P<section>\+?[^\W\d][\w-]*)\]\s*$')
+        reo = re.compile(r'^\[(?P<section>\+?[^\W\d][\w-]*)\]\s*$')
         sections = OrderedDict()
         section,contents = '',[]
         while not rdr.eof():

--- a/doc/asciidoc.conf
+++ b/doc/asciidoc.conf
@@ -3,5 +3,5 @@
 #
 [specialwords]
 ifndef::doctype-manpage[]
-monospacedwords=(?u)\\?\basciidoc\(1\) (?u)\\?\ba2x\(1\)
+monospacedwords=\\?\basciidoc\(1\) \\?\ba2x\(1\)
 endif::doctype-manpage[]

--- a/docbook45.conf
+++ b/docbook45.conf
@@ -47,7 +47,7 @@ latexmath-style=template="latexmathblock",subs=(),posattrs=(),filter="unwraplate
 [macros]
 # math macros.
 (?su)[\\]?(?P<name>latexmath):(?P<subslist>\S*?)\[(?:\$\s*)?(?P<passtext>.*?)(?:\s*\$)?(?<!\\)\]=[]
-(?u)^(?P<name>latexmath)::(?P<subslist>\S*?)(\[(?:\\\[\s*)?(?P<passtext>.*?)(?:\s*\\\])?\])$=#[]
+^(?P<name>latexmath)::(?P<subslist>\S*?)(\[(?:\\\[\s*)?(?P<passtext>.*?)(?:\s*\\\])?\])$=#[]
 
 [latexmath-inlinemacro]
 <inlineequation>

--- a/examples/website/layout1.conf
+++ b/examples/website/layout1.conf
@@ -22,7 +22,7 @@
 #   xhtml11 backend stylesheets.
 
 [specialwords]
-monospacedwords=(?u)\\?\basciidoc\(1\) (?u)\\?\ba2x\(1\)
+monospacedwords=\\?\basciidoc\(1\) \\?\ba2x\(1\)
 
 [header]
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"

--- a/examples/website/layout2.conf
+++ b/examples/website/layout2.conf
@@ -24,7 +24,7 @@
 #   xhtml11 backend stylesheets.
 
 [specialwords]
-monospacedwords=(?u)\\?\basciidoc\(1\) (?u)\\?\ba2x\(1\)
+monospacedwords=\\?\basciidoc\(1\) \\?\ba2x\(1\)
 
 [header]
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"

--- a/html5.conf
+++ b/html5.conf
@@ -36,13 +36,13 @@ asciimath-style=template="asciimathblock",subs=()
 latexmath-style=template="latexmathblock",subs=(),posattrs=(),filter="unwraplatex.py"
 
 [macros]
-(?u)^(?P<name>audio|video)::(?P<target>\S*?)(\[(?P<attrlist>.*?)\])$=#
+^(?P<name>audio|video)::(?P<target>\S*?)(\[(?P<attrlist>.*?)\])$=#
 # math macros.
 # Special characters are escaped in HTML math markup.
 (?su)[\\]?(?P<name>asciimath):(?P<subslist>\S*?)\[(?P<passtext>.*?)(?<!\\)\]=[specialcharacters]
-(?u)^(?P<name>asciimath)::(?P<subslist>\S*?)(\[(?P<passtext>.*?)\])$=#[specialcharacters]
+^(?P<name>asciimath)::(?P<subslist>\S*?)(\[(?P<passtext>.*?)\])$=#[specialcharacters]
 (?su)[\\]?(?P<name>latexmath):(?P<subslist>\S*?)\[(?:\$\s*)?(?P<passtext>.*?)(?:\s*\$)?(?<!\\)\]=[specialcharacters]
-(?u)^(?P<name>latexmath)::(?P<subslist>\S*?)(\[(?:\\\[\s*)?(?P<passtext>.*?)(?:\s*\\\])?\])$=#[specialcharacters]
+^(?P<name>latexmath)::(?P<subslist>\S*?)(\[(?:\\\[\s*)?(?P<passtext>.*?)(?:\s*\\\])?\])$=#[specialcharacters]
 
 [asciimath-inlinemacro]
 `{passtext}`

--- a/xhtml11.conf
+++ b/xhtml11.conf
@@ -39,9 +39,9 @@ latexmath-style=template="latexmathblock",subs=(),posattrs=(),filter="unwraplate
 # math macros.
 # Special characters are escaped in HTML math markup.
 (?su)[\\]?(?P<name>asciimath):(?P<subslist>\S*?)\[(?P<passtext>.*?)(?<!\\)\]=[specialcharacters]
-(?u)^(?P<name>asciimath)::(?P<subslist>\S*?)(\[(?P<passtext>.*?)\])$=#[specialcharacters]
+^(?P<name>asciimath)::(?P<subslist>\S*?)(\[(?P<passtext>.*?)\])$=#[specialcharacters]
 (?su)[\\]?(?P<name>latexmath):(?P<subslist>\S*?)\[(?:\$\s*)?(?P<passtext>.*?)(?:\s*\$)?(?<!\\)\]=[specialcharacters]
-(?u)^(?P<name>latexmath)::(?P<subslist>\S*?)(\[(?:\\\[\s*)?(?P<passtext>.*?)(?:\s*\\\])?\])$=#[specialcharacters]
+^(?P<name>latexmath)::(?P<subslist>\S*?)(\[(?:\\\[\s*)?(?P<passtext>.*?)(?:\s*\\\])?\])$=#[specialcharacters]
 
 [asciimath-inlinemacro]
 `{passtext}`


### PR DESCRIPTION
    DeprecationWarning: Flags not at the start of the expression '^(?u)[^\\W\\d][-\\w]*$'

Fixes https://github.com/asciidoc/asciidoc-py3/issues/13

Unicode regexes are default on Python 3:

https://docs.python.org/3/library/re.html#re.ASCII