### PR TITLE
Update dockerfile to better run all components of asciidoc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
 FROM ubuntu:18.04
 
-RUN apt-get update
-RUN apt-get install -y python3 dvipng graphviz imagemagick lilypond source-highlight texlive-latex-base
+RUN apt-get update && \
+    apt-get install -y python3 autoconf make wget unzip libxml2-utils xsltproc && \
+    apt-get install -y dvipng graphviz imagemagick lilypond source-highlight texlive-latex-base docbook-xsl
+
+COPY . "/srv/asciidoc"
+WORKDIR "/srv/asciidoc"


### PR DESCRIPTION
This PR splits out the Docker related changes from #5.

It accomplishes the following:
* Add in necessary sources to validate docbook types offline (`xmllint --nonet`, part of a2x.py)
* Copy in the current directory into the Docker image to be used
* Set the working directory to be the directory that contains the asciidoc source code

Validation of system:
- installation of Docker on Mac (https://docs.docker.com/docker-for-mac/install/)
- `docker build . -t asciidoc-py3:latest`
- `docker run -it --rm asciidoc-py3:latest`
and once inside docker:
- `./tests/testasciidoc.py run`
- `xmllint --nonet --noout --valid tests/data/article-docbook.xml`

Note: Running a2x.py via make is still broken pending #17 and some other parts to be pulled out of #5 to be other PRs.

Next steps for docker:
* Migrate from using Ubuntu to Alpine for Docker image
* Write documentation in INSTALL.txt
* Discuss possibly pushing Asciidoc image to [Docker Hub](https://hub.docker.com/)?