### PR TITLE
Fix some filters using python2 shebang line

### DIFF
--- a/filters/latex/latex2img.py
+++ b/filters/latex/latex2img.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 '''
 NAME
     latex2img - Converts LaTeX source to PNG or SVG file

--- a/filters/music/music2png.py
+++ b/filters/music/music2png.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 '''
 NAME
     music2png - Converts textual music notation to classically notated PNG file

--- a/filters/unwraplatex.py
+++ b/filters/unwraplatex.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 '''
 NAME
     unwraplatex - Removes delimiters from LaTeX source text


### PR DESCRIPTION
These don't affect the running of asciidoc so I missed that these weren't changed (as it executes things using the [python executable](https://github.com/asciidoc/asciidoc-py3/blob/master/asciidoc.py#L706-L707) and doesn't rely on them shebang line).

Broken out of #5.