### PR TITLE
Fix encoding issue when using subprocess in a2x

### DIFF
--- a/a2x.py
+++ b/a2x.py
@@ -214,7 +214,7 @@ def shell(cmd, raise_error=True):
     stdout = stderr = subprocess.PIPE
     try:
         popen = subprocess.Popen(cmd, stdout=stdout, stderr=stderr,
-                                 shell=True, env=ENV)
+                                 shell=True, env=ENV, universal_newlines=True)
     except OSError as e:
         die('failed: %s: %s' % (cmd, e))
     stdoutdata, stderrdata = popen.communicate()


### PR DESCRIPTION
This was a bug I encountered when running the make process (and it was compiling a2x man page). subprocess.Popen returns binary strings in Python3. We need to either manually decode them or use universal_newlines to get them into unicode strings. 

Once Python 3.4 is dropped, it'd probably make sense to replace this call with using `subprocess.run`.