### PR TITLE
Fix a2x decoding file contents according to file encoding

### DIFF
--- a/a2x.py
+++ b/a2x.py
@@ -254,15 +254,11 @@ def find_resources(files, tagname, attrname, filter=None):
         if OPTIONS.dry_run:
             continue
         parser = FindResources()
-        # HTMLParser has problems with non-ASCII strings.
-        # See http://bugs.python.org/issue3932
-        contents = read_file(filename)
-        mo = re.search(r'\A<\?xml.* encoding="(.*?)"', contents)
-        if mo:
-            encoding = mo.group(1)
-            parser.feed(contents.decode(encoding))
-        else:
-            parser.feed(contents)
+        with open(filename, 'rb') as open_file:
+            contents = open_file.read()
+        mo = re.search(b'\A<\?xml.* encoding="(.*?)"', contents)
+        contents = contents.decode(mo.group(1).decode('utf-8') if mo else 'utf-8')
+        parser.feed(contents)
         parser.close()
     result = list(set(result))   # Drop duplicate values.
     result.sort()


### PR DESCRIPTION
Fixes #16 

This makes it so that we either load the file into a unicode string based on the encoding it specifies or just defaulting to utf-8 if that's not known. We could probably actually just decode the encoding string as a ascii.