### PR TITLE
Update gitignore for make and test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,13 @@ tests/data/*.png
 # ignore doc products
 doc/*.md5
 doc/*.ly
+doc/*.svg
+doc/*.png
+doc/*.1
+doc/*.html
+
+# ignore the configure/make products
+/autom4te.cache/
+/config.*
+/configure
+Makefile


### PR DESCRIPTION
Updates the .gitignore to ignore files that are generated as a result of running make and the test suite. Given that these files haven't yet been checked into the repo, I assume that they should be properly ignored.