### PR TITLE
Use system independent timezone for testing

### DIFF
--- a/tests/testasciidoc.py
+++ b/tests/testasciidoc.py
@@ -86,7 +86,7 @@ def normalize_data(lines):
 def mock_localtime(f, _localtime=time.localtime):
     """Mock time module to generate stable output."""
     _frozentime = 0X3DE170D6
-    _frozentz = 'Pacific/Auckland'
+    _frozentz = 'UTC+00'
 
     def _frozen_localtime(t=_frozentime + 1):
         assert t > _frozentime, 'File created before first public release'


### PR DESCRIPTION
This sets the timezone to be the same across all systems regardless of underlying system. The "Pacific/Auckland" specification requires that the system running it have a tzfile installed (generally found at `/usr/share/zoneinfo`), however some number of Docker images don't come up with that by default, meaning the timezone doesn't work. Uses the python specification to ensure all tests are therefore always run as being in the UTC timezone with no offset, regardless of availability of tcfile.

See https://docs.python.org/3/library/time.html#time.tzset for reference.