### PR TITLE
Remove CNAME for gh-pages

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-asciidoc.org


### PR DESCRIPTION
File isn't necessary till the asciidoc-py2 repo is completely deprecated and asiidoc.org is set to point to this repo.