### PR TITLE
PEP8-related formatting fixes

### DIFF
--- a/asciidoc.py
+++ b/asciidoc.py
@@ -266,10 +266,10 @@ def is_safe_file(fname, directory=None):
     elif directory == '':
         directory = '.'
     return (
-        not safe()
-        or file_in(fname, directory)
-        or file_in(fname, APP_DIR)
-        or file_in(fname, CONF_DIR)
+        not safe() or
+        file_in(fname, directory) or
+        file_in(fname, APP_DIR) or
+        file_in(fname, CONF_DIR)
     )
 
 
@@ -1648,9 +1648,9 @@ class Document(object):
         attrs = self.attributes  # Alias for readability.
         s = s.strip()
         mo = re.match(r'^(?P<name1>[^<>\s]+)'
-                '(\s+(?P<name2>[^<>\s]+))?'
-                '(\s+(?P<name3>[^<>\s]+))?'
-                '(\s+<(?P<email>\S+)>)?$', s)
+                      '(\s+(?P<name2>[^<>\s]+))?'
+                      '(\s+(?P<name3>[^<>\s]+))?'
+                      '(\s+<(?P<email>\S+)>)?$', s)
         if not mo:
             # Names that don't match the formal specification.
             if s:


### PR DESCRIPTION
As discussed in #3, this is a PR for PEP8-related fixes. Currently this only covers the main asciidoc.py file. The great bulk consists of "add-space-after-comma", but there's also a few static methods decorations, spelling fixes, etc.

Between each commit I did run and verify that all of the included tests passed; someone may want to independently verify that.