### PR TITLE
fix strategy of AsciiDocAPI Search for the asciidoc command file:

### DIFF
--- a/asciidocapi.py
+++ b/asciidocapi.py
@@ -192,9 +192,8 @@ class AsciiDocAPI(object):
             if not os.path.isfile(cmd):
                 raise AsciiDocError('missing file: %s' % cmd)
         else:
-            # try to find sibling
+            # try to find sibling paths
             this_path = os.path.dirname(os.path.realpath(__file__))
-            # Try sibling paths.
             for fname in ['asciidoc.py','asciidoc.pyc','asciidoc']:
                 cmd = find_in_path(fname, path=this_path)
                 if cmd: break


### PR DESCRIPTION
also search for sibling files before for system wide path.