### PR TITLE
Add version and vers_update make endpoints to replicate from endpoints from AAP

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -23,6 +23,7 @@ srcdir = @srcdir@
 VPATH = @srcdir@
 
 ASCIIDOCVERSION = @PACKAGE_VERSION@
+ASCIIDOCDATE = @PACKAGE_DATE@
 ASCIIDOCCONF = $(sysconfdir)/asciidoc
 
 prog = asciidoc.py a2x.py
@@ -143,10 +144,14 @@ fixconfpath:
 		chmod +x $$f; \
 	done
 
+.PHONY: version
+version:
+	@echo "Version $(ASCIIDOCVERSION) (released $(ASCIIDOCDATE))";
+
 .PHONY: vers_update
 vers_update:
 	@for f in $(prog); do \
-		echo "Setting VERSION in $$f"; \
+		echo "Setting VERSION in $$f to $(ASCIIDOCVERSION)"; \
 		$(SED) "s#^VERSION = '.*'#VERSION = '$(ASCIIDOCVERSION)'#" $$f > $$f.out; \
 		mv $$f.out $$f; \
 		chmod +x $$f; \

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,7 @@
 AC_INIT(asciidoc, 8.6.10)
 
+AC_SUBST([PACKAGE_DATE], ['22 September 2017'])
+
 AC_CONFIG_FILES(Makefile)
 
 AC_PROG_SED


### PR DESCRIPTION
One of the points from #44 was the version for distribution was cumbersome to change (requiring three different changes). This reduces it to just one. Make now has a `version` endpoint (`make version`) that writes the version that's set in `configure.ac` at the top of the file to `asciidoc.py` and `a2x.py`.