### PR TITLE
tests: Add missing requires directive for source-highlight

### DIFF
--- a/tests/testasciidoc.conf
+++ b/tests/testasciidoc.conf
@@ -956,6 +956,9 @@ data/newline.txt
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 Include Line Ranges
 
+% requires
+['source-highlight']
+
 % backends
 ['html5']
 


### PR DESCRIPTION
Otherwise the test fails in environments without `source-highlight`:

  [snip]
  70: Newline Tests (Override To MAC)
  SOURCE: asciidoc: tests/data/newline.txt
  PASSED: html5: tests/data/newline-mac-html5.html
  71: Include Line Ranges
  SOURCE: asciidoc: tests/data/include-lines-test.txt
  FAILED: html5: tests/data/include-lines-html5.html
  TOTAL PASSED:  233
  TOTAL FAILED:  1
  TOTAL SKIPPED: 10
  /bin/sh: source-highlight: command not found
  /bin/sh: source-highlight: command not found
  /bin/sh: source-highlight: command not found