### PR TITLE
Reset gravity before using trim on convert

### DIFF
--- a/asciidoc/resources/filters/music/music2png.py
+++ b/asciidoc/resources/filters/music/music2png.py
@@ -151,7 +151,13 @@ def music2png(format, infile, outfile, modified):
     # Chop the bottom 75 pixels off to get rid of the page footer then crop the
     # music image. The -strip option necessary because FOP does not like the
     # custom PNG color profile used by Lilypond.
-    run('convert "%s" -strip -gravity South -chop 0x75 -trim "%s"' % (outfile, outfile))
+    # We reset the +gravity before running -trim to avoid a bug in GraphicsMagick.
+    run(
+        'convert "%s" -strip -gravity South -chop 0x75 +gravity -trim "%s"' % (
+            outfile,
+            outfile
+        )
+    )
     for f in temps:
         if os.path.isfile(f):
             print_verbose('deleting: %s' % f)


### PR DESCRIPTION
Fixes #194 

This PR resets the `+gravity` before we call `-trim` when running the convert command as part of the music filter. From what I can tell, GraphicsMagick has a bug where using the `-trim` option after altering the `-gravity` results in a warning and the `-trim` operation not being applied, whereas ImageMagick happily works. Reseting the gravity to its default value (`NorthWest`, or through `+gravity`) gets `-trim` to work as expected. Resetting the gravity in IM has no effect on `-trim` either way.

_Note_: This will be backported to 9.x