### PR TITLE
Fix running make docs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,8 +74,8 @@ jobs:
         run: |
           autoconf
           ./configure
-          make
-          pip3 install .
+          make install
+          make docs
           asciidoc --version
           a2x --version
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,12 +70,16 @@ jobs:
       - run: time python tests/testasciidoc.py run
       - run: git clean -x -f doc tests/data
 
-      - name: Test make install
+      - name: Configure make
         run: |
           autoconf
           ./configure
-          make install
-          make docs
+
+      - run: make install
+      - run: sudo make docs
+
+      - name: Print versions
+        run: |
           asciidoc --version
           a2x --version
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -104,13 +104,9 @@ docs:
 	$(INSTALL) -d $(DESTDIR)$(docdir)
 	$(INSTALL_DATA) $(doc) $(DESTDIR)$(docdir)
 	$(INSTALL) -d $(DESTDIR)$(docdir)/docbook-xsl
-	$(INSTALL_DATA) docbook-xsl/asciidoc-docbook-xsl.txt $(DESTDIR)$(docdir)/docbook-xsl
+	$(INSTALL_DATA) asciidoc/resources/docbook-xsl/asciidoc-docbook-xsl.txt $(DESTDIR)$(docdir)/docbook-xsl
 	$(INSTALL) -d $(DESTDIR)$(docdir)/dblatex
-	$(INSTALL_DATA) dblatex/dblatex-readme.txt $(DESTDIR)$(docdir)/dblatex
-	$(INSTALL) -d $(DESTDIR)$(docdir)/stylesheets
-	$(INSTALL_DATA) $(css) $(DESTDIR)$(docdir)/stylesheets
-	$(INSTALL) -d $(DESTDIR)$(docdir)/javascripts
-	$(INSTALL_DATA) $(js) $(DESTDIR)$(docdir)/javascripts
+	$(INSTALL_DATA) asciidoc/resources/dblatex/dblatex-readme.txt $(DESTDIR)$(docdir)/dblatex
 	$(INSTALL) -d $(DESTDIR)$(docdir)/images
 	( cd images && \
 		cp -R * $(DESTDIR)$(docdir)/images )


### PR DESCRIPTION
This PR fixes that the `make docs` command was not updated to handle the new location of some of the doc files. Additionally, running `make docs` is added to the CI workflow to help ensure it does not break in the future.

Fixes #169