### PR TITLE
Configure codecov to use PR status check 

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,9 +2,12 @@ comment: false
 
 coverage:
     status:
-      project:
-        default:
-            target: auto
+        patch:
+            default:
+                target: auto
+        project:
+            default:
+                target: auto
 
 github_checks:
     annotations: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+comment: false
+
+coverage:
+    status:
+      project:
+        default:
+            target: auto
+
+github_checks:
+    annotations: false


### PR DESCRIPTION
This setups a GH status check for if code coverage goes up or down, also disables the PR comment as I don't find it super useful.