### PR TITLE
Improve handling escaped attributes inside macro targets

### DIFF
--- a/tests/test_asciidoc.py
+++ b/tests/test_asciidoc.py
@@ -1,0 +1,39 @@
+from asciidoc import asciidoc
+import io
+import pytest
+
+
+@pytest.mark.parametrize(
+    "input,expected",
+    (
+        (
+            '\\{attach}file.txt',
+            '<div class="paragraph"><p>{attach}file.txt</p></div>\r\n'
+        ),
+        (
+            'link:\\{attach}file.txt[file]',
+            '<div class="paragraph"><p>' +
+            '<a href="{attach}file.txt">file</a></p></div>\r\n'
+        ),
+        (
+            'image:\\{attach}file.jpg[]',
+            '<div class="paragraph"><p><span class="image">\r\n' +
+            '<img src="{attach}file.jpg" alt="{attach}file.jpg" />\r\n' +
+            '</span></p></div>\r\n'
+        ),
+        (
+            'image:\\{attach}file.jpg[foo]',
+            '<div class="paragraph"><p><span class="image">\r\n' +
+            '<img src="{attach}file.jpg" alt="foo" />\r\n</span></p></div>\r\n'
+        ),
+    )
+)
+def test_ignore_attribute(input, expected):
+    infile = io.StringIO(input)
+    outfile = io.StringIO()
+    options = [
+        ('--out-file', outfile),
+        ('--no-header-footer', '')
+    ]
+    asciidoc.execute('asciidoc', options, [infile])
+    assert outfile.getvalue() == expected

--- a/tests/test_asciidoc.py
+++ b/tests/test_asciidoc.py
@@ -7,8 +7,16 @@ import pytest
     "input,expected",
     (
         (
+            '{attach}file.txt',
+            '<div class="paragraph"><p></p></div>\r\n'
+        ),
+        (
             '\\{attach}file.txt',
             '<div class="paragraph"><p>{attach}file.txt</p></div>\r\n'
+        ),
+        (
+            'link:{attach}file.txt[file]',
+            '<div class="paragraph"><p></p></div>\r\n'
         ),
         (
             'link:\\{attach}file.txt[file]',


### PR DESCRIPTION
Fixes #200 

This PR improves the handling of escaped attributes inside macro targets. Previously, something like `link:\{attach}foo.jpg[]` would cause the line to be dropped. This was due to the multiple passes the parser does over the line, as shown below:

```
# reads in this line:
link:\{attach}foo.jpg[]
# this gets saved internally into, dropping the escaping slash:
# {'name': 'link', 'target': '{attach}foo.jpg'}

# asciidoc then resolves it against conf:
'<a href="{target}">{0={target}}</a>'

# asciidoc parser then makes a pass over each key, value in above dictionary
# parsing them again
# key: name
link

# key: target
{attach}foo.jpg

# at which point it completes the transformation:
<a href="{attach}foo.jpg">{0={attach}foo.jpg}</a>

# and then does one last parse over the final object:
<a href="{attach}foo.jpg">{attach}foo.jpg</a>
```

The prior code would parse the first line right, but then on the second render of the `target` key/value pair, would drop that line as `{attach}foo.jpg` was considered invalid because the slash was parsed out. 

This PR modifies the parser code here to detect instances wherein we're doing a sub-parse of something that's already been parsed so we can ignore the condition on which we'd normally skip it. As such, that parse of the `target` key/value is marked as "ignored" (as we're doing a repetitive parse), and thus gets passed through. This repeats again on the parsing of the `a` tag after we replace the `{target}` attributes, where we detect that we've already parsed the values, and so do no need to skip on these cases.

There are unfortunately still some edge-cases that are not handled properly, like escaped positional attributes such as `\{0}`, due to some backends relying on those attributes missing on subsequent line parses to drop them from the output (e.g. `<<_intro>> <<_intro,intro>> xref:_intro[] _intro_` in a docbook). This unfortunately would require a greater rewriting of the parser to carry through more stateful information, than just passing through strings such for a given line, keep track of what attributes have been parsed in prior passes, though I'm at the moment stumped on how to exactly do that.
