### PR TITLE
Fix handling escaped attributes inside macros

### DIFF
--- a/tests/test_asciidoc.py
+++ b/tests/test_asciidoc.py
@@ -1,0 +1,65 @@
+from asciidoc import asciidoc
+import io
+import pytest
+
+
+@pytest.mark.parametrize(
+    "input,expected",
+    (
+        (
+            '{attach}file.txt',
+            '<div class="paragraph"><p></p></div>\r\n'
+        ),
+        (
+            '\\{attach}file{0}.txt',
+            '<div class="paragraph"><p></p></div>\r\n'
+        ),
+        (
+            '\\{attach}file.txt',
+            '<div class="paragraph"><p>{attach}file.txt</p></div>\r\n'
+        ),
+        (
+            '\\{0}file.txt',
+            '<div class="paragraph"><p>{0}file.txt</p></div>\r\n'
+        ),
+        (
+            'link:{attach}file.txt[file]',
+            '<div class="paragraph"><p></p></div>\r\n'
+        ),
+        (
+            'link:\\{attach}file.txt[file]',
+            '<div class="paragraph"><p>' +
+            '<a href="{attach}file.txt">file</a></p></div>\r\n'
+        ),
+        (
+            'link:\\{attach}file\\{0}.txt[file\\{bar}too\\{1}]',
+            '<div class="paragraph"><p><a href="{attach}file{0}.txt">' +
+            'file{bar}too{1}</a></p></div>\r\n'
+        ),
+        (
+            'image:\\{attach}file.jpg[]',
+            '<div class="paragraph"><p><span class="image">\r\n' +
+            '<img src="{attach}file.jpg" alt="{attach}file.jpg" />\r\n' +
+            '</span></p></div>\r\n'
+        ),
+        (
+            'image:\\{attach}file.jpg[foo]',
+            '<div class="paragraph"><p><span class="image">\r\n' +
+            '<img src="{attach}file.jpg" alt="foo" />\r\n</span></p></div>\r\n'
+        ),
+        (
+            'image:\\{attach}file.jpg[\\{bar}?]',
+            '<div class="paragraph"><p><span class="image">\r\n' +
+            '<img src="{attach}file.jpg" alt="{bar}?" />\r\n</span></p></div>\r\n'
+        ),
+    )
+)
+def test_ignore_attribute(input, expected):
+    infile = io.StringIO(input)
+    outfile = io.StringIO()
+    options = [
+        ('--out-file', outfile),
+        ('--no-header-footer', '')
+    ]
+    asciidoc.execute('asciidoc', options, [infile])
+    assert outfile.getvalue() == expected


### PR DESCRIPTION
Fixes #200 

This PR improves the handling of escaped attributes inside macro targets. Previously, something like `link:\{attach}foo.jpg[]` would cause the line to be dropped. This was due to the multiple passes the parser does over the line, as shown below:

```
# reads in this line:
link:\{attach}foo.jpg[]
# this gets saved internally into, dropping the escaping slash:
# {'name': 'link', 'target': '{attach}foo.jpg'}

# asciidoc then resolves it against conf:
'<a href="{target}">{0={target}}</a>'

# asciidoc parser then makes a pass over each key, value in above dictionary
# parsing them again
# key: name
link

# key: target
{attach}foo.jpg

# at which point it completes the transformation:
<a href="{attach}foo.jpg">{0={attach}foo.jpg}</a>

# and then does one last parse over the final object:
<a href="{attach}foo.jpg">{attach}foo.jpg</a>
```

The prior code would parse the first line right, but then on the second render of the `target` key/value pair, would drop that line as `{attach}foo.jpg` was considered invalid because the slash was parsed out. While an additional backlash could be inserted, it would still always end up failing on the final parse over the completed `a` tag.

This PR modifies the parser such that now it no longer permanently drops the `\` on each parse, such that in the above parse looks something like:

```
# reads in this line:
link:\{attach}foo.jpg[]
# this gets saved internally into, dropping the escaping slash:
# {'name': 'link', 'target': '\{attach}foo.jpg'}

# asciidoc then resolves it against conf:
'<a href="{target}">{0={target}}</a>'

# asciidoc parser then makes a pass over each key, value in above dictionary
# parsing them again
# key: name
link

# key: target
\{attach}foo.jpg

# at which point it completes the transformation:
<a href="\{attach}foo.jpg">{0=\{attach}foo.jpg}</a>

# and then does one last parse over the final object:
<a href="\{attach}foo.jpg">\{attach}foo.jpg</a>
```

within each of these steps, the parser converts the attribute from `\{attach}` to `{\attach}`, does all the regex matching and manipulations, and then un-transforms it back to `\{attach}`. As such, each step of the parser works as expected in ignoring the escaped attribute. Finally, when we go to _write_ the string to the outfile, we do a final parse that removes the `\` character to give us our final string `<a href="{attach}foo.jpg">{attach}foo.jpg</a>`.

This approach escapes the pitfalls / edge cases of #205, while looking to be equally effective.