### PR TITLE
add redirect for asciidoc.org/userguide.html

### DIFF
--- a/userguide.html
+++ b/userguide.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://asciidoc-py.github.io/userguide.html</title>
+<meta http-equiv="refresh" content="0; URL=https://asciidoc-py.github.io/userguide.html">
+<link rel="canonical" href="https://asciidoc-py.github.io/userguide.html">


### PR DESCRIPTION
There are still references to the original location of the User Guide on asciidoc.org. I think these URLs should be preserved rather than returning a 404 page.