### PR TITLE
Add missing resource files to pip installs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-recursive-include asciidoc/resources *.conf *.txt *.py *.png *.js *.css
+recursive-include asciidoc/resources *.conf *.txt *.py *.png *.js *.css *.xsl *.sty


### PR DESCRIPTION
Fixes #207 

Files were missing from the `asciidoc/resources/dblatex` and `asciidoc/resources/docbook-xsl` folders when doing `pip install asciidoc`. This fixes that.