### PR TITLE
Fix incorrect parsing of asciidoc_opts in a2x

### DIFF
--- a/asciidoc/a2x.py
+++ b/asciidoc/a2x.py
@@ -980,7 +980,7 @@ def cli():
     opts, args = parser.parse_args(argv)
     if len(args) != 1:
         parser.error('incorrect number of arguments')
-    opts.asciidoc_opts = [x.split(' ', 1) for x in opts.asciidoc_opts]
+    opts.asciidoc_opts = [x.split(' ') for x in opts.asciidoc_opts]
     opts.dblatex_opts = ' '.join(opts.dblatex_opts)
     opts.fop_opts = ' '.join(opts.fop_opts)
     opts.xsltproc_opts = ' '.join(opts.xsltproc_opts)


### PR DESCRIPTION
Closes: #218 

This fix simply removes the limitation of allowed options in `asciidoc_opts`. Previously only two words were allowed.

@osmith42: Could you verify that this fix works? The print before the exception now only outputs
`missing configuration file: ../build/mscgen-filter.conf`. I don't have this file.

Issue #218 highlights another problem. Printing the error message to stderr isn't working, when a2x is called. The problem is here:
https://github.com/asciidoc-py/asciidoc-py/blob/74823bed08e7b823d2b6cba8636a1fd67fed6cc9/asciidoc/asciidoc.py#L135