### PR TITLE
Run homebrew release step under macos

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,11 @@ jobs:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
 
+  homebrew:
+    runs-on: macos-latest
+    needs:
+      - release
+    steps:
       - name: Update Homebrew formula
         uses: dawidd6/action-homebrew-bump-formula@v3
         with:


### PR DESCRIPTION
Closes #211

PR moves to running the homebrew release step under `macos-latest` so that it properly targets the main homebrew repo, instead of the deprecated/archived linuxbrew repo.