### PR TITLE
a2x: fix index out of range in exec path print

### DIFF
--- a/asciidoc/a2x.py
+++ b/asciidoc/a2x.py
@@ -676,10 +676,7 @@ class A2X(AttrDict):
         options.append(('-a', 'a2x-format=%s' % self.format))
         options.append(('--out-file', docbook_file))
 
-        verbose("executing: asciidoc {} {}".format(
-            ' '.join(map(lambda x: "{}{}".format(x[0], " " + x[1] if x[1] else ""), options)),
-            self.asciidoc_file
-        ))
+        verbose("executing: asciidoc {}".format(options))
 
         asciidoc.cli(flatten(['asciidoc'] + options + [self.asciidoc_file]))
         if not self.no_xmllint and XMLLINT:


### PR DESCRIPTION
Let python format the options list, instead of iterating over it.

Fix for:
```
    File "/usr/lib/python3/dist-packages/asciidoc/a2x.py", line 684, in <lambda>
      ' '.join(map(lambda x: "{}{}".format(x[0], " " + x[1] if x[1] else ""), options)),
  IndexError: tuple index out of range
```

Example output:
> a2x: executing: asciidoc [['-f', '/usr/share/osmo-gsm-manuals/build/mscgen-filter.conf', '-f', '/usr/share/osmo-gsm-manuals/build/diag-filter.conf', '-f', '/usr/share/osmo-gsm-manuals/build/docinfo-releaseinfo.conf', '-a', "srcdir='/home/user/code/osmo-dev/src/osmo-bts/doc/manuals'", '-a', "commondir='/usr/share/osmo-gsm-manuals/common'"], ('--attribute', 'docinfo'), ('--attribute', 'revnumber=DRAFT '), ('--attribute', 'revdate=unknown'), ('--verbose',), ('--backend', 'docbook'), ('-a', 'a2x-format=pdf'), ('--out-file', '/home/user/code/osmo-dev/src/osmo-bts/doc/manuals/osmobts-usermanual.xml')]

---

@MasterOdin: asciidoc 10.1.0 with the above bug is currently in debian sid, and breaks building manuals for all of our packages. Creating a new release with this fixup or a smiliar one would be great.