### PR TITLE
Fix verbose flag not working when using a2x or asciidoc entry points

### DIFF
--- a/asciidoc/a2x.py
+++ b/asciidoc/a2x.py
@@ -1004,6 +1004,7 @@ def parse_args(argv):
 
 def cli():
     global OPTIONS
+    asciidoc.set_caller("__main__")
     argv, opts, args = parse_args(sys.argv)
     opts = eval(str(opts))  # Convert optparse.Values to dict.
     a2x = A2X(opts)
@@ -1021,5 +1022,4 @@ def cli():
 #####################################################################
 
 if __name__ == "__main__":
-    asciidoc.set_caller(__name__)
     cli()

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -9,7 +9,7 @@ Copyright (C) 2013-2022 AsciiDoc Contributors.
 Free use of this software is granted under the terms of the GNU General Public
 License as published by the Free Software Foundation; either version 2 of the
 License, or (at your option) any later version.
-    
+
 This program is distributed in the hope that it will be useful, but WITHOUT ANY
 WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 PARTICULAR PURPOSE.  See the GNU General Public License for more details.
@@ -5864,6 +5864,7 @@ def execute(cmd, opts, args):
 
 
 def cli(argv=None):
+    set_caller("__main__")
     if argv is None:
         argv = sys.argv
     # Process command line options.


### PR DESCRIPTION
Fixes #251 

This PR fixes usage of the `--verbose` flag when going through the `a2x` or `asciidoc` entry points. The root cause of the bug lies in that for the verbose output to work, it relies on the main execution being done through essentially the check `__name__ == "__main__"`:

https://github.com/asciidoc-py/asciidoc-py/blob/f23720c3969edb5394f8fc8bedaa9b4ae54c4184/asciidoc/message.py#L35-L36

When executing from the entry points, `self.application_caller` here (and `__name__` in the `asciidoc.asciidoc` module which this inherits from) would be `asciidoc.asciidoc` as opposed to `__main__`, and so nothing would be printed. This bug does not occur if executing asciidoc as a module (`python3 -m asciidoc`) as that goes through the `__main__` module which sets the application_caller to `__main__`.

To better unify behavior between the two, now, whenever the `cli` method is called in either the `a2x` or `asciidoc` modules, the application caller is set to `__main__` with the assumption that the application is being used in an interactive way where the `--verbose` flag makes sense. Programmatic usage of either module is then encouraged to go through the `execute` method in either module to avoid this.