### PR TITLE
Run apt-get update before install on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,7 @@ jobs:
 
       - name: Install apt dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             docbook-xml \
             docbook-xsl \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,6 +105,7 @@ jobs:
 
       - name: Install apt dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             docbook-xml \
             docbook-xsl \
@@ -154,6 +155,7 @@ jobs:
 
       - name: Install apt dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             docbook-xml \
             docbook-xsl \


### PR DESCRIPTION
Not sure why this has suddenly started failing, but running `apt-get update` first fixes it so not going to look any deeper.