### PR TITLE
Adding basics for compat attribute flag

### DIFF
--- a/asciidoc/__init__.py
+++ b/asciidoc/__init__.py
@@ -3,7 +3,37 @@
 import sys
 from .__metadata__ import VERSION, __version__
 
-__all__ = ['VERSION', '__version__']
+__all__ = [
+    'VERSION',
+    '__version__',
+    'set_legacy_compat',
+    'set_future_compat',
+    'set_compat_mode',
+    'get_compat_mode',
+]
+
+COMPAT_MODE = 1
+
+
+def set_legacy_compat() -> None:
+    set_compat_mode(1)
+
+
+def set_future_compat() -> None:
+    set_compat_mode(2)
+
+
+def set_compat_mode(mode: int) -> None:
+    if mode < 1 or mode > 2:
+        raise ValueError('compat mode must be 1 <= mode <= 2')
+
+    global COMPAT_MODE
+    COMPAT_MODE = mode
+
+
+def get_compat_mode() -> int:
+    return COMPAT_MODE
+
 
 # If running as a script, we avoid these imports to avoid a circular
 # RuntimeWarning, which is fine as we don't use them in that case.

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -37,13 +37,14 @@ import unicodedata
 
 from collections import OrderedDict
 
+# from . import set_future_compat, set_legacy_compat
+from . import utils
 from .attrs import parse_attributes
 from .blocks.table import parse_table_span_spec, Cell, Column
 from .collections import AttrDict, InsensitiveDict
 from .exceptions import EAsciiDoc
 from .message import Message
 from .plugin import Plugin
-from . import utils
 
 CONF_DIR = os.path.join(os.path.dirname(__file__), 'resources')
 METADATA = {}
@@ -5654,6 +5655,12 @@ def asciidoc(backend, doctype, confiles, infile, outfile, options):
         # Set the default embedded icons directory.
         if 'data-uri' in document.attributes and not os.path.isdir(document.attributes['iconsdir']):
             document.attributes['iconsdir'] = os.path.join(document.attributes['asciidoc-confdir'], 'icons')
+        # Set compat mode
+        # TODO: Enable this in 10.3 (see https://github.com/asciidoc-py/asciidoc-py/issues/254)
+        # if 'future-compat' in document.attributes:
+        #     set_future_compat()
+        # if 'legacy-compat' in document.attributes or 'compat-mode' in document.attributes:
+        #     set_legacy_compat()
         # Configuration is fully loaded.
         config.expand_all_templates()
         # Check configuration for consistency.


### PR DESCRIPTION
PR adds the basics for the compat attribute flag (#254), but does not yet reserve the flags in document attributes. The plan is to announce the reservation of the attributes in 10.2 and see if anyone complains about that it would affect them, and then rollout support in 10.3.