### PR TITLE
Update website as part of release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,10 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
+          
+      - name: Update website
+        run: curl -XPOST -u "${{ secrets.PAT_USERNAME}}:${{secrets.PAT_TOKEN}}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/asciidoc-py/asciidoc-py.github.io/actions/workflows/publish.yml/dispatches --data '{"ref": "main"}'
+    
 
   homebrew:
     runs-on: macos-latest
@@ -60,3 +64,4 @@ jobs:
           formula: asciidoc
           tag: ${{github.ref}}
           revision: ${{github.sha}}
+          

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,9 +48,17 @@ jobs:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
           
-      - name: Update website
-        run: curl -XPOST -u "${{ secrets.PAT_USERNAME }}:${{ secrets.PAT_TOKEN }}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/asciidoc-py/asciidoc-py.github.io/actions/workflows/publish.yml/dispatches --data '{"ref": "main"}'
-    
+      - name: Publish website
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.PAT_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'asciidoc-py',
+              repo: 'asciidoc-py.github.io',
+              workflow_id: 'publish.yml',
+              ref: 'main'
+            })
 
   homebrew:
     runs-on: macos-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
           password: ${{ secrets.PYPI_API_TOKEN }}
           
       - name: Update website
-        run: curl -XPOST -u "${{ secrets.PAT_USERNAME}}:${{secrets.PAT_TOKEN}}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/asciidoc-py/asciidoc-py.github.io/actions/workflows/publish.yml/dispatches --data '{"ref": "main"}'
+        run: curl -XPOST -u "${{ secrets.PAT_USERNAME }}:${{ secrets.PAT_TOKEN }}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/asciidoc-py/asciidoc-py.github.io/actions/workflows/publish.yml/dispatches --data '{"ref": "main"}'
     
 
   homebrew:


### PR DESCRIPTION
PR adds a trigger to start a website rebuild on the release event within this repo. The website pulls some amount of info from this repo (latest version, changelog, etc.) as part of the rebuild process, and previously this has been a user run step as part of the release, and now it'll just happen automatically.