### PR TITLE
Add 3.11 to CI test suite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, '3.10']
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, '3.10', 3.11]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Per the [docs](https://peps.python.org/pep-0664/), Python 3.11 was released on 10/24/2022, and so we should make sure we're testing asciidoc.py against that.