### PR TITLE
Table separator may contain escapes

### DIFF
--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -2908,7 +2908,7 @@ class Table(AbstractBlock):
                 self.error('missing section: [tabletags-%s]' % t, halt=True)
         if self.separator:
             # Evaluate escape characters.
-            self.separator = ast.literal_eval('"' + self.separator + '"')
+            self.separator = ast.literal_eval('r"' + self.separator + '"')
         # TODO: Move to class Tables
         # Check global table parameters.
         elif config.pagewidth is None:


### PR DESCRIPTION
Create a trivial asciidoc document, say test.txt, with these contents:
```
= Document Header

This is a trivial AsciiDoc document.
```

When running `asciidoc test.txt` in Fedora Rawhide, which has the latest python 3.12 beta, I see this warning:
```
<unknown>:1: SyntaxWarning: invalid escape sequence '\S'
```

The issue is that `self.separator` can contain an escape sequence, so the code should include an 'r' to ask for evaluation of a raw string.  This fixes the issue with python 3.12.  I have not tried earlier versions of python.  I'm relying on your CI to tell me if a more complex approach is needed.

This may be related to https://github.com/asciidoc-py/asciidoc-py/issues/239.