### PR TITLE
Replaced `mktemp` with a safer API `mkstemp`

### DIFF
--- a/asciidoc/resources/filters/latex/latex2img.py
+++ b/asciidoc/resources/filters/latex/latex2img.py
@@ -138,7 +138,7 @@ def latex2img(infile, outfile, imgfmt, dpi, modified):
     outdir = os.path.dirname(outfile)
     if not os.path.isdir(outdir):
         raise EApp('directory does not exist: %s' % outdir)
-    texfile = tempfile.mktemp(suffix='.tex', dir=os.path.dirname(outfile))
+    fd, texfile = tempfile.mkstemp(suffix='.tex', dir=os.path.dirname(outfile))
     basefile = os.path.splitext(texfile)[0]
     dvifile = basefile + '.dvi'
     temps = [basefile + ext for ext in ('.tex', '.dvi', '.aux', '.log')]
@@ -190,6 +190,7 @@ def latex2img(infile, outfile, imgfmt, dpi, modified):
             if os.path.isfile(f):
                 print_verbose('deleting: %s' % f)
                 os.remove(f)
+        os.close(fd)
     if 'md5_file' in locals():
         print_verbose('writing: %s' % md5_file)
         write_file(md5_file, checksum, 'wb')


### PR DESCRIPTION
## Details
While triaging your project, our bug fixing tool generated the following message(s)-

> In file: [latex2img.py](https://github.com/asciidoc-py/asciidoc-py/blob/main/asciidoc/resources/filters/latex/latex2img.py#L141), there is a method that creates a temporary file using an unsafe API mktemp. The use of this method is discouraged in the [Python documentation](https://docs.python.org/3/library/tempfile.html#tempfile.mktemp). iCR suggested that a temporary file should be created using `mkstemp` which is a [safe API](https://docs.python.org/3/library/tempfile.html#tempfile.mkstemp). iCR replaced the usage of mktemp with `mkstemp`.

> In file: [music2png.py](https://github.com/asciidoc-py/asciidoc-py/blob/main/asciidoc/resources/filters/music/music2png.py#L115), there is a method that creates a temporary file using an unsafe API mktemp. The use of this method is discouraged in the [Python documentation](https://docs.python.org/3/library/tempfile.html#tempfile.mktemp). iCR suggested that a temporary file should be created using `mkstemp` which is a [safe API](https://docs.python.org/3/library/tempfile.html#tempfile.mkstemp). iCR replaced the usage of mktemp with `mkstemp`.

Among these two cases, the first one should be fixed. Since the `texfile` is being created with the unsafe `mktemp()` method and later written to. It is to note that files created using the `mktemp()` API are less strictive and allow attackers to overwrite/link the files. Whereas, the safer API - `mkstemp()` is created in a safer way.

In the second case, it appears that the `mktemp()` method is used to generate a random name for a file. The files with individual extensions are created using command line tools. Since it doesn't lead to any unsafe behavior, this warning can be ignored.


## Changes
- Replaced the `mktemp()` method with `mkstemp()` method. And closed the file descriptor associated with it to prevent a file descriptor leak.


## CLA Requirements
*This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.*

All contributed commits are already automatically signed off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
\- [Git Commit SignOff documentation](https://developercertificate.org/)


## Sponsorship and Support
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.
