### PR TITLE
Increase readability

### DIFF
--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -1449,13 +1449,9 @@ class Header:
 class AttributeEntryMeta(type):
     def __repr__(cls):
         return "class AttributeEntry({})".format(json.dumps({
-            "pattern": cls.pattern,
-            "subs": cls.subs,
             "name": cls.name,
-            "name2": cls.name2,
             "value": cls.value,
-            "attributes": cls.attributes,
-        }, indent=2))
+        }))
 
 class AttributeEntry(metaclass=AttributeEntryMeta):
     """Static methods and attributes only."""

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -1688,7 +1688,7 @@ class Title:
         Title.linecount = None
 
     @staticmethod
-    def __repr__():
+    def __str__():
         return "class Title({})".format(str({
             "subs": Title.subs,
             "pattern": Title.pattern,
@@ -1987,7 +1987,7 @@ class Section:
         prev_sectname = Title.sectname
         Title.translate()
         if Title.level == 0 and document.doctype != 'book':
-            raise OnlyBookLvl0Sections(f"only book doctypes can contain level 0 sections; Title: {repr(Title)}; document: {repr(document)};")
+            raise OnlyBookLvl0Sections(f"only book doctypes can contain level 0 sections; Title: {Title}; document: {document};")
         if Title.level > document.level \
                 and 'basebackend-docbook' in document.attributes \
                 and prev_sectname in ('colophon', 'abstract',

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -2584,6 +2584,10 @@ class List(AbstractBlock):
                 # Titled elements terminate the list.
                 break
             next = Lex.next_element()
+            if not next
+                print("Lexer: reached end of file, no more translation")
+                sys.stdout.flush()
+                break
             if next in lists.open:
                 break
             elif isinstance(next, List):

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -905,11 +905,13 @@ class Lex:
         reader.skip_blank_lines()
         if reader.eof():
             print("Lexer: No next element, because eof")
+            sys.stdout.flush()
             return None
         # Optimization: If we've already checked for an element at this
         # position return the element.
         if Lex.prev_element and Lex.prev_cursor == reader.cursor:
             print("Lexer: return already checked element")
+            sys.stdout.flush()
             return Lex.prev_element
         if AttributeEntry.isnext():
             result = AttributeEntry
@@ -940,6 +942,7 @@ class Lex:
         Lex.prev_cursor = reader.cursor
         Lex.prev_element = result
         print(f"Lexer: return element '{result}'")
+        sys.stdout.flush()
         return result
 
     @staticmethod

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -4245,24 +4245,9 @@ class Reader(Reader1):
 
     def __repr__(self):
         return "class Reader({})".format(json.dumps({
-            "f": str(self.f),
             "fname": self.fname,
-            "next": self.next,
             "cursor": self.cursor,
-            "tabsize": self.tabsize,
-            "parent": self.parent,
-            "_lineno": self._lineno,
-            "line_ranges": self.line_ranges,
-            "current_depth": self.current_depth,
-            "max_depth": self.max_depth,
-            "bom": self.bom,
-            "infile": self.infile,
-            "indir": self.indir,
-            "depth": self.depth,
-            "skip": self.skip,
-            "skipname": self.skipname,
-            "skipto": self.skipto,
-        }, indent=2))
+        }))
 
     def read_super(self):
         result = Reader1.read(self, self.skip)

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -2605,8 +2605,10 @@ class List(AbstractBlock):
         self.number_style = None  # Current numbered list style ('arabic'..)
 
     def __repr__(self):
+        print({"__parent__", AbstractBlock.__repr__(self))
+        sys.stdout.flush()
         return "class List({})".format(json.dumps({
-            "__parent__" : json.loads(AbstractBlock.__repr__(self)),
+            "__parent_parsed__" : json.loads(AbstractBlock.__repr__(self)),
             "CONF_ENTRIES": self.CONF_ENTRIES,
             "PARAM_NAMES": self.PARAM_NAMES,
             "type": self.type,

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -1815,10 +1815,7 @@ class Title(metaclass=MetaTitle):
             for k, v in list(Title.attributes.items()):
                 if v is None:
                     del Title.attributes[k]
-        try:
-            Title.level += int(document.attributes.get('leveloffset', '0'))
-        except:
-            pass
+
         Title.attributes['level'] = str(Title.level)
         return result
 

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -2107,7 +2107,7 @@ class AbstractBlock:
         self.mo = None
 
     def __repr__(self):
-        match = self.mo.match
+        match = self.mo
         match_string = match.string[:match.start] + "[" + match.string[match.start:match.end] + "]" + match.string[m.end:]
         return "class AbstractBlock({})".format(json.dumps({
             "defname": self.defname,

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -1687,7 +1687,7 @@ class BlockTitle:
             BlockTitle.title = None
 
 
-class MetaTitle:
+class MetaTitle(type):
     """ only to manipulate __repr__ of the Title class.
     """
 

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -2107,14 +2107,9 @@ class AbstractBlock:
         self.mo = None
 
     def __repr__(self):
-        match = self.mo
-        print(match, match.string, match.start(), match.end())
-        print(str(match))
-        sys.stdout.flush()
-        match_string = match.string[:match.start] + "[" + match.string[match.start:match.end] + "]" + match.string[m.end:]
         return "class AbstractBlock({})".format(json.dumps({
             "defname": self.defname,
-            "match": match_string,
+            "match": str(self.mo),
         }, indent=2))
 
     @staticmethod

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -4262,8 +4262,22 @@ class Reader(Reader1):
 
     def __repr__(self):
         return "class Reader({})".format(json.dumps({
-            "f": self.f,
-
+            "fname": self.fname,
+            "next": self.next,
+            "cursor": self.cursor,
+            "tabsize": self.tabsize,
+            "parent": self.parent,
+            "_lineno": self._lineno,
+            "line_ranges": self.line_ranges,
+            "current_depth": self.current_depth,
+            "max_depth": self.max_depth,
+            "bom": self.bom,
+            "infile": self.infile,
+            "indir": self.indir,
+            "depth": type(self.depth),
+            "skip": type(self.skip),
+            "skipname": type(self.skipname),
+            "skipto": type(self.skipto),
         }, indent=2))
 
     def read_super(self):

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -1028,12 +1028,9 @@ class Lex:
             lines[i] = ' ' * margin + lines[i][width:]
         return lines
 
-
-# ---------------------------------------------------------------------------
-# Document element classes parse AsciiDoc reader input and write DocBook writer
-# output.
-# ---------------------------------------------------------------------------
 class Document(object):
+    """ parse AsciiDocand write DocBook
+    """
     # doctype property.
     def getdoctype(self):
         return self.attributes.get('doctype')

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -3774,7 +3774,7 @@ class Macro:
 
     def __repr__(self):
         return "class Macro({})".format(json.dumps({
-            "pattern": self.pattern,
+            "pattern": str(self.pattern),
             "name": self.name,
             "prefix": self.prefix,
             "reo": self.reo,

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -3777,7 +3777,7 @@ class Macro:
             "pattern": str(self.pattern),
             "name": self.name,
             "prefix": self.prefix,
-            "reo": self.reo,
+            "reo": str(self.reo),
             "subslist": self.subslist,
         }, indent=2))
 

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -1688,7 +1688,7 @@ class Title:
         Title.linecount = None
 
     @staticmethod
-    def __str__():
+    def __repr__():
         return "class Title({})".format(str({
             "subs": Title.subs,
             "pattern": Title.pattern,
@@ -1987,7 +1987,7 @@ class Section:
         prev_sectname = Title.sectname
         Title.translate()
         if Title.level == 0 and document.doctype != 'book':
-            raise OnlyBookLvl0Sections(f"only book doctypes can contain level 0 sections; Title: {Title.__str__()}; document: {document};")
+            raise OnlyBookLvl0Sections(f"only book doctypes can contain level 0 sections; Title: {Title.__repr__()}; document: {document};")
         if Title.level > document.level \
                 and 'basebackend-docbook' in document.attributes \
                 and prev_sectname in ('colophon', 'abstract',

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -2595,10 +2595,8 @@ class List(AbstractBlock):
         self.number_style = None  # Current numbered list style ('arabic'..)
 
     def __repr__(self):
-        print("__parent__", AbstractBlock.__repr__(self))
-        sys.stdout.flush()
         return "class List({})".format(json.dumps({
-            "__parent__" : AbstractBlock.get_repr_dict(self),
+            "__AbstractBlock__" : AbstractBlock.get_repr_dict(self),
             "CONF_ENTRIES": self.CONF_ENTRIES,
             "PARAM_NAMES": self.PARAM_NAMES,
             "type": self.type,

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -938,7 +938,7 @@ class Lex:
         # Optimization: Cache answer.
         Lex.prev_cursor = reader.cursor
         Lex.prev_element = result
-        print(f"Lexer: return element '{result}'")
+        print(f"Lexer: return element: {result}; reader: {reader} ")
         sys.stdout.flush()
         return result
 

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -2584,7 +2584,7 @@ class List(AbstractBlock):
                 # Titled elements terminate the list.
                 break
             next = Lex.next_element()
-            if not next
+            if not next:
                 print("Lexer: reached end of file, no more translation")
                 sys.stdout.flush()
                 break

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -1687,6 +1687,25 @@ class BlockTitle:
             BlockTitle.title = None
 
 
+class MetaTitle:
+    """ only to manipulate __repr__ of the Title class
+    """
+
+    
+    def __repr__(cls):
+        # TODO this doesn't seem to work automatically with static methods
+        return "class Title({})".format(json.dumps({
+            "subs": cls.subs,
+            "pattern": cls.pattern,
+            "level": cls.level,
+            "attributes": cls.attributes,
+            "sectname": cls.sectname,
+            "section_numbers" : cls.section_numbers,
+            "dump_dict" : cls.dump_dict,
+            "linecount" : cls.linecount,
+        }, indent=2))
+
+
 class Title:
     """Processes Header and Section titles. Static methods and attributes
     only."""
@@ -1714,20 +1733,6 @@ class Title:
         Title.section_numbers = [0] * len(Title.underlines)
         Title.dump_dict = {}
         Title.linecount = None
-
-    @staticmethod
-    def __repr__():
-        # TODO this doesn't seem to work automatically with static methods
-        return "class Title({})".format(json.dumps({
-            "subs": Title.subs,
-            "pattern": Title.pattern,
-            "level": Title.level,
-            "attributes": Title.attributes,
-            "sectname": Title.sectname,
-            "section_numbers" : Title.section_numbers,
-            "dump_dict" : Title.dump_dict,
-            "linecount" : Title.linecount,
-        }, indent=2))
 
     @staticmethod
     def translate(skipsubs=False):

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -1699,7 +1699,7 @@ class Title:
             "section_numbers" : Title.section_numbers,
             "dump_dict" : Title.dump_dict,
             "linecount" : Title.linecount,
-        }))
+        }, indent=2))
 
     @staticmethod
     def translate(skipsubs=False):

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -2107,9 +2107,11 @@ class AbstractBlock:
         self.mo = None
 
     def __repr__(self):
+        match = self.mo.match
+        match_string = match.string[:match.start] + "[" + match.string[match.start:match.end] + "]" + match.string[m.end:]
         return "class AbstractBlock({})".format(json.dumps({
             "defname": self.defname,
-            "match": str(self.mo.match),
+            "match": match_string,
         }, indent=2))
 
     @staticmethod

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -1987,7 +1987,7 @@ class Section:
         prev_sectname = Title.sectname
         Title.translate()
         if Title.level == 0 and document.doctype != 'book':
-            raise OnlyBookLvl0Sections(f"only book doctypes can contain level 0 sections; Title: {Title}; document: {document};")
+            raise OnlyBookLvl0Sections(f"only book doctypes can contain level 0 sections; Title: {Title.__str__()}; document: {document};")
         if Title.level > document.level \
                 and 'basebackend-docbook' in document.attributes \
                 and prev_sectname in ('colophon', 'abstract',

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -2601,7 +2601,7 @@ class List(AbstractBlock):
             "text": self.text,
             "type": self.type,
             "ordinal": self.ordinal,
-        }, indent=2))
+        }))
 
     def load(self, name, entries):
         AbstractBlock.load(self, name, entries)

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -1446,7 +1446,18 @@ class Header:
                 attrs['manvolnum'] = mo.group('manvolnum').strip()
 
 
-class AttributeEntry:
+class AttributeEntryMeta(type):
+    def __repr__(cls):
+        return "class AttributeEntry({})".format(json.dumps({
+            "pattern": cls.pattern,
+            "subs": cls.subs,
+            "name": cls.name,
+            "name2": cls.name2,
+            "value": cls.value,
+            "attributes": cls.attributes,
+        }, indent=2))
+
+class AttributeEntry(metaclass=AttributeEntryMeta):
     """Static methods and attributes only."""
     pattern = None
     subs = None
@@ -1457,16 +1468,6 @@ class AttributeEntry:
 
     def __init__(self):
         raise AssertionError('no class instances allowed')
-
-    def __repr__(self):
-        return "class AttributeEntry({})".format(json.dumps({
-            "pattern": self.pattern,
-            "subs": self.subs,
-            "name": self.name,
-            "name2": self.name2,
-            "value": self.value,
-            "attributes": self.attributes,
-        }, indent=2))
 
     @staticmethod
     def reset_class():

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -1690,6 +1690,7 @@ class Title:
 
     @staticmethod
     def __repr__():
+        # TODO this doesn't seem to work automatically with static methods
         return "class Title({})".format(json.dumps({
             "subs": Title.subs,
             "pattern": Title.pattern,
@@ -1988,7 +1989,7 @@ class Section:
         prev_sectname = Title.sectname
         Title.translate()
         if Title.level == 0 and document.doctype != 'book':
-            raise OnlyBookLvl0Sections(f"only book doctypes can contain level 0 sections; Title: {Title.__repr__()}; document: {document};")
+            raise OnlyBookLvl0Sections(f"only book doctypes can contain level 0 sections; Title: {Title.attributes["title"]}; document: {document};")
         if Title.level > document.level \
                 and 'basebackend-docbook' in document.attributes \
                 and prev_sectname in ('colophon', 'abstract',

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -1997,7 +1997,8 @@ class Section:
         prev_sectname = Title.sectname
         Title.translate()
         if Title.level == 0 and document.doctype != 'book':
-            raise OnlyBookLvl0Sections(f"only book doctypes can contain level 0 sections; Title: {Title.attributes["title"]}; document: {document};")
+            title_name = Title.attributes["title"]
+            raise OnlyBookLvl0Sections(f"only book doctypes can contain level 0 sections; Title: {title_name}; document: {document};")
         if Title.level > document.level \
                 and 'basebackend-docbook' in document.attributes \
                 and prev_sectname in ('colophon', 'abstract',

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -2106,11 +2106,14 @@ class AbstractBlock:
         # Leading delimiter match object.
         self.mo = None
 
-    def __repr__(self):
-        return "class AbstractBlock({})".format(json.dumps({
+    def get_repr_dict(self):
+        return {    
             "defname": self.defname,
             "match": str(self.mo),
-        }, indent=2))
+        }
+
+    def __repr__(self):
+        return "class AbstractBlock({})".format(self.get_repr_dict(), indent=2))
 
     @staticmethod
     def reset_class():
@@ -2595,7 +2598,7 @@ class List(AbstractBlock):
         print("__parent__", AbstractBlock.__repr__(self))
         sys.stdout.flush()
         return "class List({})".format(json.dumps({
-            "__parent_parsed__" : json.loads(AbstractBlock.__repr__(self)),
+            "__parent__" : AbstractBlock.get_repr_dict(self),
             "CONF_ENTRIES": self.CONF_ENTRIES,
             "PARAM_NAMES": self.PARAM_NAMES,
             "type": self.type,

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -2453,10 +2453,10 @@ class AbstractBlocks:
 
     def __repr__(self):
         return "class AbstractBlocks({})".format(json.dumps({
-            "current": self.current,
-            "blocks": self.blocks,
-            "default": self.default,
-            "delimiters": self.delimiters,
+            "current": str(self.current),
+            "blocks": str(self.blocks),
+            "default": str(self.default),
+            "delimiters": str(self.delimiters),
         }, indent=2))
 
     def load(self, sections):
@@ -2506,11 +2506,8 @@ class Paragraph(AbstractBlock):
 
     def __repr__(self):
         return "class Paragraph({})".format(json.dumps({
-            "current": self.current,
-            "blocks": self.blocks,
-            "default": self.default,
-            "delimiters": self.delimiters,
-            "text": self.text,
+            "__parent__" : AbstractBlock.__repr__(self),
+            "text": str(self.text),
         }, indent=2))
 
     def load(self, name, entries):
@@ -2568,10 +2565,7 @@ class Paragraphs(AbstractBlocks):
 
     def __repr__(self):
         return "class Paragraphs({})".format(json.dumps({
-            "current": self.current,
-            "blocks": self.blocks,
-            "default": self.default,
-            "delimiters": self.delimiters,
+            "__parent__" : AbstractBlock.__repr__(self),
             "terminators": self.terminators,
         }, indent=2))
 
@@ -2621,10 +2615,7 @@ class List(AbstractBlock):
 
     def __repr__(self):
         return "class List({})".format(json.dumps({
-            "current": self.current,
-            "blocks": self.blocks,
-            "default": self.default,
-            "delimiters": self.delimiters,
+            "__parent__" : AbstractBlock.__repr__(self),
             "CONF_ENTRIES": self.CONF_ENTRIES,
             "PARAM_NAMES": self.PARAM_NAMES,
             "type": self.type,
@@ -2872,10 +2863,9 @@ class Lists(AbstractBlocks):
 
     def __repr__(self):
         return "class Lists({})".format(json.dumps({
-            "current": self.current,
-            "blocks": self.blocks,
-            "default": self.default,
-            "delimiters": self.delimiters,
+            "__parent__" : AbstractBlock.__repr__(self),
+            "open": self.open,
+            "tags": self.tags,
             "terminators": self.terminators,
         }, indent=2))
 
@@ -2931,10 +2921,7 @@ class DelimitedBlock(AbstractBlock):
 
     def __repr__(self):
         return "class DelimitedBlock({})".format(json.dumps({
-            "current": self.current,
-            "blocks": self.blocks,
-            "default": self.default,
-            "delimiters": self.delimiters,
+            "__parent__" : AbstractBlock.__repr__(self),
         }, indent=2))
 
     def load(self, name, entries):
@@ -3007,10 +2994,7 @@ class DelimitedBlocks(AbstractBlocks):
 
     def __repr__(self):
         return "class DelimitedBlocks({})".format(json.dumps({
-            "current": self.current,
-            "blocks": self.blocks,
-            "default": self.default,
-            "delimiters": self.delimiters,
+            "__parent__" : AbstractBlock.__repr__(self),
         }, indent=2))
 
     def load(self, sections):
@@ -3045,10 +3029,7 @@ class Table(AbstractBlock):
 
     def __repr__(self):
         return "class Table({})".format(json.dumps({
-            "current": self.current,
-            "blocks": self.blocks,
-            "default": self.default,
-            "delimiters": self.delimiters,
+            "__parent__" : AbstractBlock.__repr__(self),
             "CONF_ENTRIES": self.CONF_ENTRIES,
             "format": self.format,
             "separator": self.separator,
@@ -3559,10 +3540,7 @@ class Tables(AbstractBlocks):
 
     def __repr__(self):
         return "class Tables({})".format(json.dumps({
-            "current": self.current,
-            "blocks": self.blocks,
-            "default": self.default,
-            "delimiters": self.delimiters,
+            "__parent__" : AbstractBlock.__repr__(self),
             "tags": self.tags,
         }, indent=2))
 

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -3738,6 +3738,13 @@ class Macros:
 
 
 class Macro:
+    """ supposedly finding Macros?
+
+    TODO: why are comment blocks parsed as Macro? The language documentation says the content is ignored. [1] And Asciidoc has Attributes, named blocks, and these `:doSomething:aboutStuff[]` processors,
+          which can be hooked by plugin writers. There's no need for in-comment macro processing, afaik.
+
+    [1] https://docs.asciidoctor.org/asciidoc/latest/comments/
+    """
     def __init__(self):
         self.pattern = None     # Matching regular expression.
         self.name = ''          # Conf file macro name (None if implicit).

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -4050,18 +4050,18 @@ class Reader1:
     def __repr__(self):
         return "class Reader1({})".format(json.dumps({
             "f": self.f,
-            "fname": (self.fname),
-            "next": (self.next),
-            "cursor": (self.cursor),
-            "tabsize": (self.tabsize),
-            "parent": (self.parent),
-            "_lineno": (self._lineno),
-            "line_ranges": (self.line_ranges),
-            "current_depth": (self.current_depth),
-            "max_depth": (self.max_depth),
-            "bom": (self.bom),
-            "infile": (self.infile),
-            "indir": (self.indir),
+            "fname": self.fname,
+            "next": self.next,
+            "cursor": self.cursor,
+            "tabsize": self.tabsize,
+            "parent": self.parent,
+            "_lineno": self._lineno,
+            "line_ranges": self.line_ranges,
+            "current_depth": self.current_depth,
+            "max_depth": self.max_depth,
+            "bom": self.bom,
+            "infile": self.infile,
+            "indir": self.indir,
         }, indent=2))
 
     def open(self, fname):
@@ -4263,22 +4263,7 @@ class Reader(Reader1):
     def __repr__(self):
         return "class Reader({})".format(json.dumps({
             "f": self.f,
-            "fname": self.fname,
-            "next": self.next,
-            "cursor": self.cursor,
-            "tabsize": self.tabsize,
-            "parent": self.parent,
-            "_lineno": self._lineno,
-            "line_ranges": self.line_ranges,
-            "current_depth": self.current_depth,
-            "max_depth": self.max_depth,
-            "bom": self.bom,
-            "infile": self.infile,
-            "indir": self.indir,
-            "depth": type(self.depth),
-            "skip": type(self.skip),
-            "skipname": type(self.skipname),
-            "skipto": type(self.skipto),
+
         }, indent=2))
 
     def read_super(self):

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -4049,19 +4049,19 @@ class Reader1:
 
     def __repr__(self):
         return "class Reader1({})".format(json.dumps({
-            "f": type(self.f),
-            "fname": type(self.fname),
-            "next": type(self.next),
-            "cursor": type(self.cursor),
-            "tabsize": type(self.tabsize),
-            "parent": type(self.parent),
-            "_lineno": type(self._lineno),
-            "line_ranges": type(self.line_ranges),
-            "current_depth": type(self.current_depth),
-            "max_depth": type(self.max_depth),
-            "bom": type(self.bom),
-            "infile": type(self.infile),
-            "indir": type(self.indir),
+            "f": self.f,
+            "fname": (self.fname),
+            "next": (self.next),
+            "cursor": (self.cursor),
+            "tabsize": (self.tabsize),
+            "parent": (self.parent),
+            "_lineno": (self._lineno),
+            "line_ranges": (self.line_ranges),
+            "current_depth": (self.current_depth),
+            "max_depth": (self.max_depth),
+            "bom": (self.bom),
+            "infile": (self.infile),
+            "indir": (self.indir),
         }, indent=2))
 
     def open(self, fname):
@@ -4275,10 +4275,10 @@ class Reader(Reader1):
             "bom": self.bom,
             "infile": self.infile,
             "indir": self.indir,
-            "depth": self.depth,
-            "skip": self.skip,
-            "skipname": self.skipname,
-            "skipto": self.skipto,
+            "depth": type(self.depth),
+            "skip": type(self.skip),
+            "skipname": type(self.skipname),
+            "skipto": type(self.skipto),
         }, indent=2))
 
     def read_super(self):

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -1998,7 +1998,10 @@ class Section:
         Title.translate()
         if Title.level == 0 and document.doctype != 'book':
             title_name = Title.attributes["title"]
-            raise OnlyBookLvl0Sections(f"only book doctypes can contain level 0 sections; Title: {title_name}; document: {document};")
+            docfile = document.attributes["docfile"]
+            doctype = document.attributes["doctype"]
+            raise OnlyBookLvl0Sections(f"only book doctypes can contain level 0 sections; Title erroring: {title_name}; current doctype: {doctype}; document: {docfile};"
+                                      + "\nNOTE: the problem might come from an import")
         if Title.level > document.level \
                 and 'basebackend-docbook' in document.attributes \
                 and prev_sectname in ('colophon', 'abstract',

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -1974,7 +1974,7 @@ class Section:
         prev_sectname = Title.sectname
         Title.translate()
         if Title.level == 0 and document.doctype != 'book':
-            raise OnlyBookLvl0Sections('only book doctypes can contain level 0 sections')
+            raise OnlyBookLvl0Sections(f"only book doctypes can contain level 0 sections; Title: {Title}; document: {document};")
         if Title.level > document.level \
                 and 'basebackend-docbook' in document.attributes \
                 and prev_sectname in ('colophon', 'abstract',

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -2597,17 +2597,10 @@ class List(AbstractBlock):
     def __repr__(self):
         return "class List({})".format(json.dumps({
             "__AbstractBlock__" : AbstractBlock.get_repr_dict(self),
-            "CONF_ENTRIES": self.CONF_ENTRIES,
-            "PARAM_NAMES": self.PARAM_NAMES,
             "type": self.type,
-            "tags": self.tags,
-            "tag": self.tag,
-            "label": self.label,
             "text": self.text,
-            "index": self.index,
             "type": self.type,
             "ordinal": self.ordinal,
-            "number_style": self.number_style,
         }, indent=2))
 
     def load(self, name, entries):

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -1690,7 +1690,7 @@ class Title:
 
     @staticmethod
     def __repr__():
-        return pprint.pprint("class Title({})".format(str({
+        return "class Title({})".format(pprint.pprint({
             "subs": Title.subs,
             "pattern": Title.pattern,
             "level": Title.level,
@@ -1699,7 +1699,7 @@ class Title:
             "section_numbers" : Title.section_numbers,
             "dump_dict" : Title.dump_dict,
             "linecount" : Title.linecount,
-        })))
+        }))
 
     @staticmethod
     def translate(skipsubs=False):

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -2120,7 +2120,7 @@ class AbstractBlock:
             "start": self.start,
             "defname": self.defname,
             "delimiter": self.delimiter,
-            "delimiter_reo": self.delimiter_reo,
+            "delimiter_reo": str(self.delimiter_reo),
             "template": self.template,
             "presubs": self.presubs,
             "postsubs": self.postsubs,
@@ -2131,7 +2131,7 @@ class AbstractBlock:
             "attributes": self.attributes,
             "PARAM_NAMES": self.PARAM_NAMES,
             "parameters": self.parameters,
-            "mo": self.mo,
+            "mo": str(self.mo),
         }, indent=2))
 
     @staticmethod

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -1987,7 +1987,7 @@ class Section:
         prev_sectname = Title.sectname
         Title.translate()
         if Title.level == 0 and document.doctype != 'book':
-            raise OnlyBookLvl0Sections(f"only book doctypes can contain level 0 sections; Title: {Title}; document: {document};")
+            raise OnlyBookLvl0Sections(f"only book doctypes can contain level 0 sections; Title: {repr(Title)}; document: {repr(document)};")
         if Title.level > document.level \
                 and 'basebackend-docbook' in document.attributes \
                 and prev_sectname in ('colophon', 'abstract',

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -3754,12 +3754,9 @@ class Macro:
 
     def __repr__(self):
         return "class Macro({})".format(json.dumps({
-            "pattern": str(self.pattern),
             "name": self.name,
             "prefix": self.prefix,
-            "reo": str(self.reo),
-            "subslist": self.subslist,
-        }, indent=2))
+        }))
 
     def has_passthrough(self):
         return self.pattern.find(r'(?P<passtext>') >= 0

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -2113,7 +2113,7 @@ class AbstractBlock:
         }
 
     def __repr__(self):
-        return "class AbstractBlock({})".format(self.get_repr_dict(), indent=2))
+        return "class AbstractBlock({})".format(self.get_repr_dict(), indent=2)
 
     @staticmethod
     def reset_class():

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -26,6 +26,7 @@ from functools import lru_cache
 import getopt
 import io
 import os
+import pprint
 import re
 import subprocess
 import sys
@@ -1689,7 +1690,7 @@ class Title:
 
     @staticmethod
     def __repr__():
-        return "class Title({})".format(str({
+        return pprint.pprint("class Title({})".format(str({
             "subs": Title.subs,
             "pattern": Title.pattern,
             "level": Title.level,
@@ -1698,7 +1699,7 @@ class Title:
             "section_numbers" : Title.section_numbers,
             "dump_dict" : Title.dump_dict,
             "linecount" : Title.linecount,
-        }))
+        })))
 
     @staticmethod
     def translate(skipsubs=False):

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -904,10 +904,12 @@ class Lex:
         line of the next element or EOF (leading blank lines are skipped)."""
         reader.skip_blank_lines()
         if reader.eof():
+            print("Lexer: No next element, because eof")
             return None
         # Optimization: If we've already checked for an element at this
         # position return the element.
         if Lex.prev_element and Lex.prev_cursor == reader.cursor:
+            print("Lexer: return already checked element")
             return Lex.prev_element
         if AttributeEntry.isnext():
             result = AttributeEntry
@@ -937,6 +939,7 @@ class Lex:
         # Optimization: Cache answer.
         Lex.prev_cursor = reader.cursor
         Lex.prev_element = result
+        print(f"Lexer: return element '{result}'")
         return result
 
     @staticmethod

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -2108,6 +2108,8 @@ class AbstractBlock:
 
     def __repr__(self):
         match = self.mo
+        print(match, match.string, match.start, match.end)
+        sys.stdout.flush()
         match_string = match.string[:match.start] + "[" + match.string[match.start:match.end] + "]" + match.string[m.end:]
         return "class AbstractBlock({})".format(json.dumps({
             "defname": self.defname,

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -905,13 +905,11 @@ class Lex:
         line of the next element or EOF (leading blank lines are skipped)."""
         reader.skip_blank_lines()
         if reader.eof():
-            print("Lexer: No next element, because eof")
             sys.stdout.flush()
             return None
         # Optimization: If we've already checked for an element at this
         # position return the element.
         if Lex.prev_element and Lex.prev_cursor == reader.cursor:
-            print("Lexer: return already checked element")
             sys.stdout.flush()
             return Lex.prev_element
         if AttributeEntry.isnext():

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -905,12 +905,10 @@ class Lex:
         line of the next element or EOF (leading blank lines are skipped)."""
         reader.skip_blank_lines()
         if reader.eof():
-            sys.stdout.flush()
             return None
         # Optimization: If we've already checked for an element at this
         # position return the element.
         if Lex.prev_element and Lex.prev_cursor == reader.cursor:
-            sys.stdout.flush()
             return Lex.prev_element
         if AttributeEntry.isnext():
             result = AttributeEntry

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -2001,7 +2001,7 @@ class Section:
             docfile = document.attributes["docfile"]
             doctype = document.attributes["doctype"]
             raise OnlyBookLvl0Sections(f"only book doctypes can contain level 0 sections; Title erroring: {title_name}; current doctype: {doctype}; document: {docfile};"
-                                      + "\nNOTE: the problem might come from an import")
+                                      + "\nNOTE: the problem might come from an import, then `leveloffset:` might help")
         if Title.level > document.level \
                 and 'basebackend-docbook' in document.attributes \
                 and prev_sectname in ('colophon', 'abstract',

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -1458,6 +1458,16 @@ class AttributeEntry:
     def __init__(self):
         raise AssertionError('no class instances allowed')
 
+    def __repr__(self):
+        return "class AttributeEntry({})".format(json.dumps({
+            "pattern": self.pattern,
+            "subs": self.subs,
+            "name": self.name,
+            "name2": self.name2,
+            "value": self.value,
+            "attributes": self.attributes,
+        }, indent=2))
+
     @staticmethod
     def reset_class():
         AttributeEntry.pattern = None
@@ -1554,6 +1564,13 @@ class AttributeList:
     def __init__(self):
         raise AssertionError('no class instances allowed')
 
+    def __repr__(self):
+        return "class AttributeList({})".format(json.dumps({
+            "pattern": self.pattern,
+            "match": self.match,
+            "attrs": self.attrs,
+        }, indent=2))
+
     @staticmethod
     def reset_class():
         AttributeList.pattern = None
@@ -1626,6 +1643,12 @@ class BlockTitle:
 
     def __init__(self):
         raise AssertionError('no class instances allowed')
+
+    def __repr__(self):
+        return "class BlockTitle({})".format(json.dumps({
+            "title": self.title,
+            "pattern": self.pattern,
+        }, indent=2))
 
     @staticmethod
     def reset_class():
@@ -1926,6 +1949,12 @@ class Section:
     def __init__(self):
         raise AssertionError('no class instances allowed')
 
+    def __repr__(self):
+        return "class Section({})".format(json.dumps({
+            "endtags": self.endtags,
+            "ids": self.ids,
+        }, indent=2))
+
     @staticmethod
     def reset_class():
         Section.endtags = []
@@ -2080,6 +2109,25 @@ class AbstractBlock:
         self.parameters = None
         # Leading delimiter match object.
         self.mo = None
+
+    def __repr__(self):
+        return "class AbstractBlock({})".format(json.dumps({
+            "start": self.start,
+            "defname": self.defname,
+            "delimiter": self.delimiter,
+            "delimiter_reo": self.delimiter_reo,
+            "template": self.template,
+            "presubs": self.presubs,
+            "postsubs": self.postsubs,
+            "filter": self.filter,
+            "posattrs": self.posattrs,
+            "style": self.style,
+            "styles": self.styles,
+            "attributes": self.attributes,
+            "PARAM_NAMES": self.PARAM_NAMES,
+            "parameters": self.parameters,
+            "mo": self.mo,
+        }, indent=2))
 
     @staticmethod
     def reset_class():
@@ -2398,6 +2446,14 @@ class AbstractBlocks:
         self.default = None     # Default Block.
         self.delimiters = None  # Combined delimiters regular expression.
 
+    def __repr__(self):
+        return "class AbstractBlocks({})".format(json.dumps({
+            "current": self.current,
+            "blocks": self.blocks,
+            "default": self.default,
+            "delimiters": self.delimiters,
+        }, indent=2))
+
     def load(self, sections):
         """Load block definition from 'sections' dictionary."""
         for k in list(sections.keys()):
@@ -2442,6 +2498,15 @@ class Paragraph(AbstractBlock):
     def __init__(self):
         AbstractBlock.__init__(self)
         self.text = None          # Text in first line of paragraph.
+
+    def __repr__(self):
+        return "class Paragraph({})".format(json.dumps({
+            "current": self.current,
+            "blocks": self.blocks,
+            "default": self.default,
+            "delimiters": self.delimiters,
+            "text": self.text,
+        }, indent=2))
 
     def load(self, name, entries):
         AbstractBlock.load(self, name, entries)
@@ -2496,6 +2561,15 @@ class Paragraphs(AbstractBlocks):
         AbstractBlocks.__init__(self)
         self.terminators = None    # List of compiled re's.
 
+    def __repr__(self):
+        return "class Paragraphs({})".format(json.dumps({
+            "current": self.current,
+            "blocks": self.blocks,
+            "default": self.default,
+            "delimiters": self.delimiters,
+            "terminators": self.terminators,
+        }, indent=2))
+
     def initialize(self):
         self.terminators = [
             re.compile(r'^\+$|^$'),
@@ -2539,6 +2613,25 @@ class List(AbstractBlock):
         self.type = None      # List type ('numbered','bulleted','labeled').
         self.ordinal = None   # Current list item ordinal number (1..)
         self.number_style = None  # Current numbered list style ('arabic'..)
+
+    def __repr__(self):
+        return "class List({})".format(json.dumps({
+            "current": self.current,
+            "blocks": self.blocks,
+            "default": self.default,
+            "delimiters": self.delimiters,
+            "CONF_ENTRIES": self.CONF_ENTRIES,
+            "PARAM_NAMES": self.PARAM_NAMES,
+            "type": self.type,
+            "tags": self.tags,
+            "tag": self.tag,
+            "label": self.label,
+            "text": self.text,
+            "index": self.index,
+            "type": self.type,
+            "ordinal": self.ordinal,
+            "number_style": self.number_style,
+        }, indent=2))
 
     def load(self, name, entries):
         AbstractBlock.load(self, name, entries)
@@ -2772,6 +2865,15 @@ class Lists(AbstractBlocks):
         self.tags = {}    # List tags dictionary. Each entry is a tags AttrDict.
         self.terminators = None    # List of compiled re's.
 
+    def __repr__(self):
+        return "class Lists({})".format(json.dumps({
+            "current": self.current,
+            "blocks": self.blocks,
+            "default": self.default,
+            "delimiters": self.delimiters,
+            "terminators": self.terminators,
+        }, indent=2))
+
     def initialize(self):
         self.terminators = [
             re.compile(r'^\+$|^$'),
@@ -2821,6 +2923,14 @@ class Lists(AbstractBlocks):
 class DelimitedBlock(AbstractBlock):
     def __init__(self):
         AbstractBlock.__init__(self)
+
+    def __repr__(self):
+        return "class DelimitedBlock({})".format(json.dumps({
+            "current": self.current,
+            "blocks": self.blocks,
+            "default": self.default,
+            "delimiters": self.delimiters,
+        }, indent=2))
 
     def load(self, name, entries):
         AbstractBlock.load(self, name, entries)
@@ -2890,6 +3000,14 @@ class DelimitedBlocks(AbstractBlocks):
     def __init__(self):
         AbstractBlocks.__init__(self)
 
+    def __repr__(self):
+        return "class DelimitedBlocks({})".format(json.dumps({
+            "current": self.current,
+            "blocks": self.blocks,
+            "default": self.default,
+            "delimiters": self.delimiters,
+        }, indent=2))
+
     def load(self, sections):
         """Update blocks defined in 'sections' dictionary."""
         AbstractBlocks.load(self, sections)
@@ -2919,6 +3037,22 @@ class Table(AbstractBlock):
         self.pcwidth = None     # 1..99 (percentage).
         self.rows = []            # Parsed rows, each row is a list of Cells.
         self.columns = []         # List of Columns.
+
+    def __repr__(self):
+        return "class Table({})".format(json.dumps({
+            "current": self.current,
+            "blocks": self.blocks,
+            "default": self.default,
+            "delimiters": self.delimiters,
+            "CONF_ENTRIES": self.CONF_ENTRIES,
+            "format": self.format,
+            "separator": self.separator,
+            "tags": self.tags,
+            "abswidth": self.abswidth,
+            "pcwidth": self.pcwidth,
+            "rows": self.rows,
+            "columns": self.columns,
+        }, indent=2))
 
     def load(self, name, entries):
         AbstractBlock.load(self, name, entries)
@@ -3418,6 +3552,15 @@ class Tables(AbstractBlocks):
         # Table tags dictionary. Each entry is a tags dictionary.
         self.tags = {}
 
+    def __repr__(self):
+        return "class Tables({})".format(json.dumps({
+            "current": self.current,
+            "blocks": self.blocks,
+            "default": self.default,
+            "delimiters": self.delimiters,
+            "tags": self.tags,
+        }, indent=2))
+
     def load(self, sections):
         AbstractBlocks.load(self, sections)
         self.load_tags(sections)
@@ -3516,6 +3659,13 @@ class Macros:
         m.prefix = '+'
         m.reo = re.compile(m.pattern)
         self.macros.append(m)
+
+    def __repr__(self):
+        return "class Macros({})".format(json.dumps({
+            "macros": self.macros,
+            "current": self.current,
+            "passthroughs": self.passthroughs,
+        }, indent=2))
 
     def load(self, entries):
         for entry in entries:
@@ -3616,6 +3766,15 @@ class Macro:
         self.prefix = ''        # '' if inline, '+' if system, '#' if block.
         self.reo = None         # Compiled pattern re object.
         self.subslist = []      # Default subs for macros passtext group.
+
+    def __repr__(self):
+        return "class Macro({})".format(json.dumps({
+            "pattern": self.pattern,
+            "name": self.name,
+            "prefix": self.prefix,
+            "reo": self.reo,
+            "subslist": self.subslist,
+        }, indent=2))
 
     def has_passthrough(self):
         return self.pattern.find(r'(?P<passtext>') >= 0
@@ -3814,6 +3973,13 @@ class CalloutMap:
         self.calloutindex = 0   # Current callout index number.
         self.listnumber = 1     # Current callout list number.
 
+    def __repr__(self):
+        return "class CalloutMap({})".format(json.dumps({
+            "comap": self.comap,
+            "calloutindex": self.calloutindex,
+            "listnumber": self.listnumber,
+        }, indent=2))
+
     def listclose(self):
         # Called when callout list is closed.
         self.listnumber += 1
@@ -3880,6 +4046,23 @@ class Reader1:
         self.bom = None         # Byte order mark (BOM).
         self.infile = None      # Saved document 'infile' attribute.
         self.indir = None       # Saved document 'indir' attribute.
+
+    def __repr__(self):
+        return "class Reader1({})".format(json.dumps({
+            "f": self.f,
+            "fname": self.fname,
+            "next": self.next,
+            "cursor": self.cursor,
+            "tabsize": self.tabsize,
+            "parent": self.parent,
+            "_lineno": self._lineno,
+            "line_ranges": self.line_ranges,
+            "current_depth": self.current_depth,
+            "max_depth": self.max_depth,
+            "bom": self.bom,
+            "infile": self.infile,
+            "indir": self.indir,
+        }, indent=2))
 
     def open(self, fname):
         self.fname = fname
@@ -4077,6 +4260,27 @@ class Reader(Reader1):
         self.skipname = ''      # Name of current endif macro target.
         self.skipto = -1        # The depth at which skipping is re-enabled.
 
+    def __repr__(self):
+        return "class Reader({})".format(json.dumps({
+            "f": self.f,
+            "fname": self.fname,
+            "next": self.next,
+            "cursor": self.cursor,
+            "tabsize": self.tabsize,
+            "parent": self.parent,
+            "_lineno": self._lineno,
+            "line_ranges": self.line_ranges,
+            "current_depth": self.current_depth,
+            "max_depth": self.max_depth,
+            "bom": self.bom,
+            "infile": self.infile,
+            "indir": self.indir,
+            "depth": self.depth,
+            "skip": self.skip,
+            "skipname": self.skipname,
+            "skipto": self.skipto,
+        }, indent=2))
+
     def read_super(self):
         result = Reader1.read(self, self.skip)
         if result is None and self.skip:
@@ -4248,6 +4452,15 @@ class Writer:
         self.lines_out = 0               # Number of lines written.
         self.skip_blank_lines = False    # If True don't output blank lines.
 
+    def __repr__(self):
+        return "class Writer({})".format(json.dumps({
+            "f": self.f,
+            "fname": self.fname,
+            "newline": self.newline,
+            "lines_out": self.lines_out,
+            "skip_blank_lines": self.skip_blank_lines,
+        }, indent=2))
+
     def open(self, fname, bom=None):
         """
         bom is optional byte order mark.
@@ -4376,6 +4589,36 @@ class Config:
         self.include1 = {}      # Holds include1::[] files for {include1:}.
         self.dumping = False    # True if asciidoc -c option specified.
         self.filters = []       # Filter names specified by --filter option.
+
+    def __repr__(self):
+        return "class Config({})".format(json.dumps({
+            "sections": self.sections,
+            "verbose": self.verbose,
+            "header_footer": self.header_footer,
+            "tabsize": self.tabsize,
+            "textwidth": self.textwidth,
+            "newline": self.newline,
+            "pagewidth": self.pagewidth,
+            "pageunits": self.pageunits,
+            "outfilesuffix": self.outfilesuffix,
+            "subsnormal": self.subsnormal,
+            "subsverbatim": self.subsverbatim,
+            "tags": self.tags,
+            "specialchars": self.specialchars,
+            "specialwords": self.specialwords,
+            "replacements": self.replacements,
+            "replacements2": self.replacements2,
+            "replacements3": self.replacements3,
+            "specialsections": self.specialsections,
+            "quotes": self.quotes,
+            "fname": self.fname,
+            "conf_attrs": self.conf_attrs,
+            "cmd_attrs": self.cmd_attrs,
+            "loaded": self.loaded,
+            "include1": self.include1,
+            "dumping": self.dumping,
+            "filters": self.filters,
+        }, indent=2))
 
     @staticmethod
     def init():

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -1068,6 +1068,7 @@ class Document(object):
             "has_warnings": self.has_warnings,
             "safe" : self.safe,
         }, indent=2))
+
     def update_attributes(self, attrs=None):
         """
         Set implicit attributes and attributes in 'attrs'.

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -1688,6 +1688,19 @@ class Title:
         Title.linecount = None
 
     @staticmethod
+    def __repr__():
+        return "class Title({})".format(str({
+            "subs": Title.subs,
+            "pattern": Title.pattern,
+            "level": Title.level,
+            "attributes": Title.attributes,
+            "sectname": Title.sectname,
+            "section_numbers" : Title.section_numbers,
+            "dump_dict" : Title.dump_dict,
+            "linecount" : Title.linecount,
+        }))
+
+    @staticmethod
     def translate(skipsubs=False):
         """Parse the Title.attributes and Title.level from the reader. The
         real work has already been done by parse()."""

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -1688,7 +1688,7 @@ class BlockTitle:
 
 
 class MetaTitle:
-    """ only to manipulate __repr__ of the Title class
+    """ only to manipulate __repr__ of the Title class.
     """
 
     
@@ -1706,7 +1706,7 @@ class MetaTitle:
         }, indent=2))
 
 
-class Title:
+class Title(metaclass=MetaTitle):
     """Processes Header and Section titles. Static methods and attributes
     only."""
     # Class variables

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -2108,21 +2108,8 @@ class AbstractBlock:
 
     def __repr__(self):
         return "class AbstractBlock({})".format(json.dumps({
-            "start": self.start,
             "defname": self.defname,
-            "delimiter": self.delimiter,
-            "delimiter_reo": str(self.delimiter_reo),
-            "template": self.template,
-            "presubs": self.presubs,
-            "postsubs": self.postsubs,
-            "filter": self.filter,
-            "posattrs": self.posattrs,
-            "style": self.style,
-            "styles": self.styles,
-            "attributes": self.attributes,
-            "PARAM_NAMES": self.PARAM_NAMES,
-            "parameters": self.parameters,
-            "mo": str(self.mo),
+            "match": str(self.mo.match),
         }, indent=2))
 
     @staticmethod

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -4247,7 +4247,7 @@ class Reader(Reader1):
     def __repr__(self):
         return "class Reader({})".format(json.dumps({
             "fname": self.fname,
-            "cursor": self.cursor,
+            "next": self.next[0],
         }))
 
     def read_super(self):

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -1696,15 +1696,9 @@ class MetaTitle(type):
     def __repr__(cls):
         # TODO this doesn't seem to work automatically with static methods
         return "class Title({})".format(json.dumps({
-            "subs": cls.subs,
-            "pattern": cls.pattern,
-            "level": cls.level,
-            "attributes": cls.attributes,
-            "sectname": cls.sectname,
-            "section_numbers" : cls.section_numbers,
-            "dump_dict" : cls.dump_dict,
-            "linecount" : cls.linecount,
-        }, indent=2))
+            "title": cls.attributes["title"],
+            "level": cls.attributes["level"],
+        }))
 
 
 class Title(metaclass=MetaTitle):

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -26,7 +26,7 @@ from functools import lru_cache
 import getopt
 import io
 import os
-import pprint
+import json
 import re
 import subprocess
 import sys
@@ -1690,7 +1690,7 @@ class Title:
 
     @staticmethod
     def __repr__():
-        return "class Title({})".format(pprint.pprint({
+        return "class Title({})".format(json.dumps({
             "subs": Title.subs,
             "pattern": Title.pattern,
             "level": Title.level,

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -2606,7 +2606,7 @@ class List(AbstractBlock):
 
     def __repr__(self):
         return "class List({})".format(json.dumps({
-            "__parent__" : AbstractBlock.__repr__(self),
+            "__parent__" : json.loads(AbstractBlock.__repr__(self)),
             "CONF_ENTRIES": self.CONF_ENTRIES,
             "PARAM_NAMES": self.PARAM_NAMES,
             "type": self.type,

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -4262,6 +4262,7 @@ class Reader(Reader1):
 
     def __repr__(self):
         return "class Reader({})".format(json.dumps({
+            "f": str(self.f),
             "fname": self.fname,
             "next": self.next,
             "cursor": self.cursor,
@@ -4274,10 +4275,10 @@ class Reader(Reader1):
             "bom": self.bom,
             "infile": self.infile,
             "indir": self.indir,
-            "depth": type(self.depth),
-            "skip": type(self.skip),
-            "skipname": type(self.skipname),
-            "skipto": type(self.skipto),
+            "depth": self.depth,
+            "skip": self.skip,
+            "skipname": self.skipname,
+            "skipto": self.skipto,
         }, indent=2))
 
     def read_super(self):

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -2108,7 +2108,8 @@ class AbstractBlock:
 
     def __repr__(self):
         match = self.mo
-        print(match, match.string, match.start, match.end)
+        print(match, match.string, match.start(), match.end())
+        print(str(match))
         sys.stdout.flush()
         match_string = match.string[:match.start] + "[" + match.string[match.start:match.end] + "]" + match.string[m.end:]
         return "class AbstractBlock({})".format(json.dumps({

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -2488,8 +2488,7 @@ class Paragraph(AbstractBlock):
     def __repr__(self):
         return "class Paragraph({})".format(json.dumps({
             "__AbstractBlock__" : AbstractBlock.get_repr_dict(self),
-            "text": str(self.text),
-        }, indent=2))
+        }))
 
     def load(self, name, entries):
         AbstractBlock.load(self, name, entries)

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -4049,19 +4049,19 @@ class Reader1:
 
     def __repr__(self):
         return "class Reader1({})".format(json.dumps({
-            "f": self.f,
-            "fname": self.fname,
-            "next": self.next,
-            "cursor": self.cursor,
-            "tabsize": self.tabsize,
-            "parent": self.parent,
-            "_lineno": self._lineno,
-            "line_ranges": self.line_ranges,
-            "current_depth": self.current_depth,
-            "max_depth": self.max_depth,
-            "bom": self.bom,
-            "infile": self.infile,
-            "indir": self.indir,
+            "f": type(self.f),
+            "fname": type(self.fname),
+            "next": type(self.next),
+            "cursor": type(self.cursor),
+            "tabsize": type(self.tabsize),
+            "parent": type(self.parent),
+            "_lineno": type(self._lineno),
+            "line_ranges": type(self.line_ranges),
+            "current_depth": type(self.current_depth),
+            "max_depth": type(self.max_depth),
+            "bom": type(self.bom),
+            "infile": type(self.infile),
+            "indir": type(self.indir),
         }, indent=2))
 
     def open(self, fname):

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -42,7 +42,7 @@ from . import utils
 from .attrs import parse_attributes
 from .blocks.table import parse_table_span_spec, Cell, Column
 from .collections import AttrDict, InsensitiveDict
-from .exceptions import EAsciiDoc
+from .exceptions import EAsciiDoc, OnlyBookLvl0Sections
 from .message import Message
 from .plugin import Plugin
 
@@ -1974,7 +1974,7 @@ class Section:
         prev_sectname = Title.sectname
         Title.translate()
         if Title.level == 0 and document.doctype != 'book':
-            message.error('only book doctypes can contain level 0 sections')
+            raise OnlyBookLvl0Sections('only book doctypes can contain level 0 sections')
         if Title.level > document.level \
                 and 'basebackend-docbook' in document.attributes \
                 and prev_sectname in ('colophon', 'abstract',

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -1058,6 +1058,16 @@ class Document(object):
         self.has_warnings = False  # Set true if warnings were flagged.
         self.safe = False       # Default safe mode.
 
+    def __repr__(self):
+        return "class Document({})".format(json.dumps({
+            "infile": self.infile,
+            "outfile": self.outfile,
+            "attributes": self.attributes,
+            "level": self.level,
+            "has_errors": self.has_errors,
+            "has_warnings": self.has_warnings,
+            "safe" : self.safe,
+        }, indent=2))
     def update_attributes(self, attrs=None):
         """
         Set implicit attributes and attributes in 'attrs'.

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -2605,7 +2605,7 @@ class List(AbstractBlock):
         self.number_style = None  # Current numbered list style ('arabic'..)
 
     def __repr__(self):
-        print({"__parent__", AbstractBlock.__repr__(self))
+        print("__parent__", AbstractBlock.__repr__(self))
         sys.stdout.flush()
         return "class List({})".format(json.dumps({
             "__parent_parsed__" : json.loads(AbstractBlock.__repr__(self)),

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -2487,7 +2487,7 @@ class Paragraph(AbstractBlock):
 
     def __repr__(self):
         return "class Paragraph({})".format(json.dumps({
-            "__parent__" : AbstractBlock.__repr__(self),
+            "__AbstractBlock__" : AbstractBlock.get_repr_dict(self),
             "text": str(self.text),
         }, indent=2))
 
@@ -2546,7 +2546,7 @@ class Paragraphs(AbstractBlocks):
 
     def __repr__(self):
         return "class Paragraphs({})".format(json.dumps({
-            "__parent__" : AbstractBlock.__repr__(self),
+            "__AbstractBlock__" : AbstractBlock.get_repr_dict(self),
             "terminators": self.terminators,
         }, indent=2))
 
@@ -2837,7 +2837,7 @@ class Lists(AbstractBlocks):
 
     def __repr__(self):
         return "class Lists({})".format(json.dumps({
-            "__parent__" : AbstractBlock.__repr__(self),
+            "__AbstractBlock__" : AbstractBlock.get_repr_dict(self),
             "open": self.open,
             "tags": self.tags,
             "terminators": self.terminators,
@@ -2895,7 +2895,7 @@ class DelimitedBlock(AbstractBlock):
 
     def __repr__(self):
         return "class DelimitedBlock({})".format(json.dumps({
-            "__parent__" : AbstractBlock.__repr__(self),
+            "__AbstractBlock__" : AbstractBlock.get_repr_dict(self),
         }, indent=2))
 
     def load(self, name, entries):
@@ -2968,7 +2968,7 @@ class DelimitedBlocks(AbstractBlocks):
 
     def __repr__(self):
         return "class DelimitedBlocks({})".format(json.dumps({
-            "__parent__" : AbstractBlock.__repr__(self),
+            "__AbstractBlock__" : AbstractBlock.get_repr_dict(self),
         }, indent=2))
 
     def load(self, sections):
@@ -3003,7 +3003,7 @@ class Table(AbstractBlock):
 
     def __repr__(self):
         return "class Table({})".format(json.dumps({
-            "__parent__" : AbstractBlock.__repr__(self),
+            "__AbstractBlock__" : AbstractBlock.get_repr_dict(self),
             "CONF_ENTRIES": self.CONF_ENTRIES,
             "format": self.format,
             "separator": self.separator,
@@ -3514,7 +3514,7 @@ class Tables(AbstractBlocks):
 
     def __repr__(self):
         return "class Tables({})".format(json.dumps({
-            "__parent__" : AbstractBlock.__repr__(self),
+            "__AbstractBlock__" : AbstractBlock.get_repr_dict(self),
             "tags": self.tags,
         }, indent=2))
 

--- a/asciidoc/exceptions.py
+++ b/asciidoc/exceptions.py
@@ -6,3 +6,8 @@ class EAsciiDoc(Exception):
 class AsciiDocError(Exception):
     """Exceptions raised by the asciidoc API"""
     pass
+
+class OnlyBookLvl0Sections(AsciiDocError):
+    """ if a level 0 section is discovered and the doctype is not book
+    """
+    pass


### PR DESCRIPTION
I know, I know. The [Asciidoc community doesn't like the Python processor anymore](https://gitlab.eclipse.org/eclipse-wg/asciidoc-wg/asciidoc.org/-/blob/main/awesome-asciidoc.adoc?plain=1#L39), but I'm a Python guy. So I tried to make it work for one of my current use cases, an [open source Obsidian clone](https://github.com/fallbackerik/secondbrain.py). And until now, I have to say it parses everything I send it. Just sometimes the error messages have been a little obscure.

So, here's a draft of how to make this compiler's activity more readable to an interested user. I wouldn't merge it yet, as it's quite verbose now. But I wanted to get some early feedback if there are still people maintaining this compiler.

Also, I see quite some more work to be done on this code base. If someone wants to cooperate with me *feel free to say hello*. Newcomers to Python and/or open source contributions are *very welcome*, as well. I'll take the time to teach you to make contributions you can be proud off, show in job interviews, etc. Trust me.

**Note**: In my last commit I deleted a workaround that was weird and that created an error in my documentation base. I think it's more healthy to not use such a workaround. But it actually might break other people's pipeline. How do we want to handle this?