### PR TITLE
Fix running test suite for python 3.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Set pip trusted host (Python3.5)
+        run: echo 'PIP_TRUSTED_HOST="pypi.python.org pypi.org files.pythonhosted.org"' >> $GITHUB_ENV
+        if: ${{ matrix.python-version == '3.5' }}
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         if: "!endsWith(matrix.python-version, '-dev')"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,21 +33,20 @@ jobs:
         include:
           - python-version: 3.5
             runs-on: ubuntu-20.04
+            trusted-host: "pypi.python.org pypi.org files.pythonhosted.org"
           - python-version: 3.6
             runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set pip trusted host (Python3.5)
-        run: echo 'PIP_TRUSTED_HOST="pypi.python.org pypi.org files.pythonhosted.org"' >> $GITHUB_ENV
-        if: ${{ matrix.python-version == '3.5' }}
-
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         if: "!endsWith(matrix.python-version, '-dev')"
         with:
           python-version: ${{ matrix.python-version }}
+        env:
+          PIP_TRUSTED_HOST: ${{ matrix.trusted-host }}
 
       - name: Set up Python ${{ matrix.python-version }} (deadsnakes)
         uses: deadsnakes/action@v2.1.1


### PR DESCRIPTION
Per https://github.com/actions/setup-python/issues/866, the version of pip bundled with python 3.5 is too old to accept the new SSL certificates that pypi.org uses, so need to set the `PIP_TRUSTED_HOST` environment variable so that pip ignores the fact that it cannot verify SSL. This does pose a security concern as it opens the door for MITM attacks, so will probably look to drop Python 3.5 support soon.