### PR TITLE
Increase readability Attempt 2

### DIFF
--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -1939,11 +1939,11 @@ class Title(metaclass=TitleMeta):
         return number
 
 
-class FloatingTitleMeta(type):
+class FloatingTitleMeta(TitleMeta):
     def get_repr_dict(cls):
         return {
             "__type__": "asciidoc.asciidoc.FloatingTitle",
-            "__super__" : super(Title, self).get_repr_dict(),
+            "__super__" : super(TitleMeta, self).get_repr_dict(),
             "title": cls.attributes["title"],
             "level": cls.attributes["level"],
         }

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -1457,7 +1457,7 @@ class AttributeEntryMeta(type):
     def get_repr_dict(cls):
         return {
             "__type__": "asciidoc.asciidoc.AttributeEntry",
-            "name": cls.infile,
+            "name": cls.name,
             "value": cls.value,
         }
         

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -1463,7 +1463,7 @@ class AttributeEntryMeta(type):
         
     def __repr__(cls):
         # TODO limit to important attributes for one-line format
-        return json.dumps(cls.get_repr_dict(), indent=2)
+        return json.dumps(cls.get_repr_dict())
 
 class AttributeEntry(metaclass=AttributeEntryMeta):
     """Static methods and attributes only."""

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -2112,10 +2112,6 @@ class Section(metaclass=SectionMeta):
             if document.backend == 'docbook' and Title.sectname != 'index':
                 message.error('empty section is not valid')
 
-
-class AbstractBlockMeta(type):
-
-
 class AbstractBlock:
     blocknames = []  # Global stack of names for push_blockname() and pop_blockname().
 

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -4317,7 +4317,7 @@ class Reader(Reader1):
         }
         
     def __repr__(self):
-        return json.dumps(self.get_repr_dict(), indent=2)
+        return json.dumps(self.get_repr_dict())
 
     def read_super(self):
         result = Reader1.read(self, self.skip)

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -3805,7 +3805,6 @@ class Macro:
     def get_repr_dict(self):
         return {
             "__type__": "asciidoc.asciidoc.Macro",
-            "__super__": super(Macro, self).get_repr_dict(),
             "name": self.name,
             "prefix": self.prefix,
         }


### PR DESCRIPTION
As mentioned in #271, I needed to create another PR since I had to move to another account.

This PR doesn't contain all the changes, though. Just the ones that make it more clear through `print()` statements, what `asciidoc-py` is actually doing. The other things will follow in later PRs.

I followed @hoadlck's advice in giving the commit messages breadcrumbs that are not auto-generated. So, I hope it's more clear for reviewing.

I would have liked to squash all the debug commits into the actual change commit, which is the first. However, lacking terminal access to any computer at all and an understanding how I could do an interactive rebase via a github workflow, I'm unsure how I could achieve that goal. Could a maintainer do the squashing part for me?

Looking forward to your feedback. Please don't merge yet.