### PR TITLE
Debug for secondbrain step 2: raise Exception and remove workaround

### DIFF
--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -1771,10 +1771,6 @@ class Title:
             for k, v in list(Title.attributes.items()):
                 if v is None:
                     del Title.attributes[k]
-        try:
-            Title.level += int(document.attributes.get('leveloffset', '0'))
-        except:
-            pass
         Title.attributes['level'] = str(Title.level)
         return result
 

--- a/asciidoc/asciidoc.py
+++ b/asciidoc/asciidoc.py
@@ -42,7 +42,7 @@ from . import utils
 from .attrs import parse_attributes
 from .blocks.table import parse_table_span_spec, Cell, Column
 from .collections import AttrDict, InsensitiveDict
-from .exceptions import EAsciiDoc
+from .exceptions import EAsciiDoc, EOnlyBookLvl0Sections
 from .message import Message
 from .plugin import Plugin
 
@@ -1968,7 +1968,12 @@ class Section:
         prev_sectname = Title.sectname
         Title.translate()
         if Title.level == 0 and document.doctype != 'book':
-            message.error('only book doctypes can contain level 0 sections')
+            title_name = Title.attributes["title"]
+            docfile = document.attributes["docfile"]
+            doctype = document.attributes["doctype"]
+            raise EOnlyBookLvl0Sections("only book doctypes can contain level 0 sections;"
+                                        + f"Title erroring: {title_name}; current doctype: {doctype}; document: {docfile};"
+                                        + "\nNOTE: the problem might come from an import, then `leveloffset:` might help")
         if Title.level > document.level \
                 and 'basebackend-docbook' in document.attributes \
                 and prev_sectname in ('colophon', 'abstract',

--- a/asciidoc/exceptions.py
+++ b/asciidoc/exceptions.py
@@ -2,6 +2,10 @@ class EAsciiDoc(Exception):
     """Exceptions raised by the main asciidoc process"""
     pass
 
+class EOnlyBookLvl0Sections(EAsciiDoc):
+    """ Parser only allows lvl 0 headings on doctype book
+    """
+    pass
 
 class AsciiDocError(Exception):
     """Exceptions raised by the asciidoc API"""

--- a/asciidoc/exceptions.py
+++ b/asciidoc/exceptions.py
@@ -2,10 +2,12 @@ class EAsciiDoc(Exception):
     """Exceptions raised by the main asciidoc process"""
     pass
 
+
 class EOnlyBookLvl0Sections(EAsciiDoc):
     """ Parser only allows lvl 0 headings on doctype book
     """
     pass
+
 
 class AsciiDocError(Exception):
     """Exceptions raised by the asciidoc API"""


### PR DESCRIPTION
with the help of the changes from #274 I found the need to change the following parts:

 1. There's an internal, manually created logging mechanism that even does errors/exceptions. I removed it for one point where I ran into an error and created an exception instead. Maybe this can be extended to the whole file? i.e. logging instead of message printing, and exceptions where it creates errors. I like the idea of error counting, but this could be also done in a try-catch that simply rethrows the same exception after counting it.
 1. I found that there's a workaround that dynamically changes the level of headings, does so silently without informing the user, and without much checking of what actually happens before, therefore rather randomly. To me this workaround looks more like a bug, so I removed it.

**Attention:** Although I believe that removing the workaround is the right decision, [there's a good chance it breaks someone's code](https://xkcd.com/1172/). How do we want to handle such changes?

 - *Just do it!* And deal with some users getting angry?
 - Slowly introducing the change and giving people time to adapt?
 - Leave it in there, but offer users another method to call which doesn't contain it?
 - Something else?