### PR TITLE
Allow python to be provided in Makefile

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -29,6 +29,7 @@ doc = $(wildcard README*) $(wildcard BUGS*) $(wildcard INSTALL*) $(wildcard CHAN
 
 TARGETS = doc
 
+PYTHON ?= python3
 DESTDIR ?= /
 
 INSTDIRS = $(TARGETS:%=%dir)
@@ -53,7 +54,7 @@ $(INSTDIRS):
 	$(INSTALL) -d $(DESTDIR)$($@)
 
 $(manp): %.1 : %.1.txt
-	python3 -m asciidoc.a2x -f manpage $<
+	$(PYTHON) -m asciidoc.a2x -f manpage $<
 
 ##.
 
@@ -78,7 +79,7 @@ doc_spell: spell
 
 .PHONY: pip
 pip:
-	python3 -m pip install --root $(DESTDIR) .
+	$(PYTHON) -m pip install --root $(DESTDIR) .
 
 ##   install: install asciidoc to target directory
 .PHONY: install
@@ -109,7 +110,7 @@ docs:
 ##   uninstall: uninstall asciidoc
 .PHONY: uninstall
 uninstall:
-	python3 -m pip uninstall asciidoc
+	$(PYTHON) -m pip uninstall asciidoc
 	rm -f $(DESTDIR)$(manpdir)/asciidoc.1
 	rm -f $(DESTDIR)$(manpdir)/testasciidoc.1
 	rm -f $(DESTDIR)$(manpdir)/a2x.1
@@ -121,7 +122,7 @@ clean:
 	rm -f $(manp)
 
 MANIFEST: build_manifest.py
-	python3 build_manifest.py
+	$(PYTHON) build_manifest.py
 
 ##.
 ##   dist: creates the zip and tarball for release
@@ -140,6 +141,6 @@ dist: manpages MANIFEST
 ##   test: run the asciidoc test suite
 .PHONY: test
 test:
-	python3 -m asciidoc.asciidoc --doctest
-	python3 -m pytest
-	python3 tests/testasciidoc.py run
+	$(PYTHON) -m asciidoc.asciidoc --doctest
+	$(PYTHON) -m pytest
+	$(PYTHON) tests/testasciidoc.py run


### PR DESCRIPTION
When 'python3' is used to do the install (through `make install`) then the shbang on the installed program will be /usr/bin/python3. For systems with more than one python, it is better to invoke with python3.X so that the shbang has the proper value (/usr/bin/python3.X rather than /usr/bin/python3).